### PR TITLE
[SELC-3900] fix: Changed implementation of api using UserInfo collection instead of UserInstitution

### DIFF
--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/response/UserInstitutionRoleResponse.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/response/UserInstitutionRoleResponse.java
@@ -1,6 +1,7 @@
 package it.pagopa.selfcare.user.controller.response;
 
 import it.pagopa.selfcare.onboarding.common.PartyRole;
+import it.pagopa.selfcare.user.constant.OnboardedProductState;
 import lombok.Data;
 
 @Data
@@ -8,6 +9,7 @@ public class UserInstitutionRoleResponse {
 
     private String institutionId;
     private String institutionName;
+    private String institutionRootName;
     private PartyRole role;
-
+    private OnboardedProductState status;
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/entity/UserInstitutionRole.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/entity/UserInstitutionRole.java
@@ -11,6 +11,7 @@ public class UserInstitutionRole {
 
     private String institutionId;
     private String institutionName;
+    private String institutionRootName;
     private PartyRole role;
     private OnboardedProductState status;
 

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/mapper/UserMapper.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/mapper/UserMapper.java
@@ -1,12 +1,8 @@
 package it.pagopa.selfcare.user.mapper;
 
-import it.pagopa.selfcare.user.controller.response.OnboardedProductResponse;
-import it.pagopa.selfcare.user.controller.response.UserNotificationResponse;
-import it.pagopa.selfcare.user.controller.response.UserResponse;
+import it.pagopa.selfcare.user.controller.response.*;
 import it.pagopa.selfcare.user.controller.response.product.InstitutionProducts;
 import it.pagopa.selfcare.user.controller.response.product.UserProductsResponse;
-import it.pagopa.selfcare.user.entity.OnboardedProduct;
-import it.pagopa.selfcare.user.entity.UserInstitution;
 import it.pagopa.selfcare.user.model.notification.UserNotificationToSend;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -40,16 +36,22 @@ public interface UserMapper {
     }
     @Mapping(target = "id", source = "userId")
     @Mapping(target = "bindings", expression = "java(userInstitutionToBindings(userInstitution))")
-    default UserProductsResponse toUserProductsResponse(List<UserInstitution> userInstitutions) {
+    default UserProductsResponse toUserProductsResponse(UserInfoResponse userInfoResponse) {
         UserProductsResponse response = new UserProductsResponse();
-        if(userInstitutions != null && !userInstitutions.isEmpty()) {
-            response.setId(userInstitutions.get(0).getUserId());
+        if(userInfoResponse != null && !userInfoResponse.getInstitutions().isEmpty()) {
+            response.setId(userInfoResponse.getUserId());
 
-            List<InstitutionProducts> institutionProducts = userInstitutions.stream().map(userInstitution -> {
+            List<InstitutionProducts> institutionProducts = userInfoResponse.getInstitutions().stream().map(userInstitution -> {
                 InstitutionProducts institutionProduct = new InstitutionProducts();
                 institutionProduct.setInstitutionId(userInstitution.getInstitutionId());
-                institutionProduct.setInstitutionName(userInstitution.getInstitutionDescription());
-                institutionProduct.setProducts(toProducts(userInstitution.getProducts()));
+                institutionProduct.setInstitutionName(userInstitution.getInstitutionName());
+                institutionProduct.setInstitutionRootName(userInstitution.getInstitutionRootName());
+
+                OnboardedProductResponse product = new OnboardedProductResponse();
+                product.setRole(userInstitution.getRole());
+                product.setStatus(userInstitution.getStatus());
+
+                institutionProduct.setProducts(List.of(product));
                 return institutionProduct;
             }).toList();
             response.setBindings(institutionProducts);
@@ -57,7 +59,5 @@ public interface UserMapper {
 
         return response;
     }
-
-    List<OnboardedProductResponse> toProducts(List<OnboardedProduct> products);
 
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserService.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserService.java
@@ -4,13 +4,13 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
 import it.pagopa.selfcare.user.constant.OnboardedProductState;
+import it.pagopa.selfcare.user.controller.response.UserInfoResponse;
 import it.pagopa.selfcare.user.controller.response.UserInstitutionResponse;
 import it.pagopa.selfcare.user.controller.response.UserProductResponse;
 import it.pagopa.selfcare.user.model.notification.UserNotificationToSend;
 import org.openapi.quarkus.user_registry_json.model.UserResource;
 
 import java.util.List;
-import it.pagopa.selfcare.user.entity.UserInstitution;
 
 
 public interface UserService {
@@ -20,7 +20,7 @@ public interface UserService {
 
     Uni<UserResource> retrievePerson(String userId, String productId, String institutionId);
 
-    Uni<List<UserInstitution>> retrieveBindings(String institutionId, String userId, String[] states);
+    Uni<UserInfoResponse> retrieveBindings(String institutionId, String userId, String[] states);
 
     Uni<Void> updateUserStatusWithOptionalFilter(String userId, String institutionId, String productId, PartyRole role, String productRole, OnboardedProductState status);
 

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/util/UserUtils.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/util/UserUtils.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.user.util;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
 import it.pagopa.selfcare.product.service.ProductService;
 import it.pagopa.selfcare.user.constant.OnboardedProductState;
+import it.pagopa.selfcare.user.controller.response.UserInfoResponse;
 import it.pagopa.selfcare.user.entity.UserInstitution;
 import it.pagopa.selfcare.user.exception.InvalidRequestException;
 import it.pagopa.selfcare.user.mapper.NotificationMapper;
@@ -91,5 +92,18 @@ public class UserUtils {
         return Arrays.stream(states)
                 .map(OnboardedProductState::valueOf)
                 .collect(Collectors.toList());
+    }
+
+    public UserInfoResponse filterInstitutionRoles(UserInfoResponse userInfo, String[] states, String institutionId) {
+        List<OnboardedProductState> onboardedProductStates = Optional.ofNullable(states)
+                .map(this::convertStatesToOnboardedProductStates)
+                .orElse(null);
+
+        if (Objects.nonNull(userInfo.getInstitutions())) {
+            userInfo.getInstitutions().removeIf(institution -> (!Objects.isNull(onboardedProductStates) && !onboardedProductStates.contains(institution.getStatus()))
+                    || (!Objects.isNull(institutionId) && !institution.getInstitutionId().equalsIgnoreCase(institutionId))
+            );
+        }
+        return userInfo;
     }
 }

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/controller/UserControllerTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/controller/UserControllerTest.java
@@ -7,8 +7,9 @@ import io.quarkus.test.security.TestSecurity;
 import io.restassured.http.ContentType;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.user.constant.OnboardedProductState;
+import it.pagopa.selfcare.user.controller.response.UserInfoResponse;
 import it.pagopa.selfcare.user.controller.response.UserInstitutionResponse;
-import it.pagopa.selfcare.user.entity.UserInstitution;
+import it.pagopa.selfcare.user.controller.response.UserInstitutionRoleResponse;
 import it.pagopa.selfcare.user.exception.InvalidRequestException;
 import it.pagopa.selfcare.user.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.user.model.notification.UserNotificationToSend;
@@ -21,6 +22,7 @@ import org.openapi.quarkus.user_registry_json.model.CertifiableFieldResourceOfst
 import org.openapi.quarkus.user_registry_json.model.UserResource;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -236,12 +238,19 @@ class UserControllerTest {
     @Test
     @TestSecurity(user = "userJwt")
     void testGetUserProductsInfoOk() {
+        UserInfoResponse userInfoResponse = new UserInfoResponse();
+        userInfoResponse.setUserId("test-user");
 
-        UserInstitution userInstitution = new UserInstitution();
-        userInstitution.setUserId("test-user");
+        UserInstitutionRoleResponse userInstitution = new UserInstitutionRoleResponse();
+        userInstitution.setInstitutionName("test-institutionId");
+        userInstitution.setStatus(OnboardedProductState.ACTIVE);
+
+        List<UserInstitutionRoleResponse> userInstitutionRoleResponses = new ArrayList<>();
+        userInstitutionRoleResponses.add(userInstitution);
+        userInfoResponse.setInstitutions(userInstitutionRoleResponses);
 
         Mockito.when(userService.retrieveBindings(any(), any(), any()))
-                .thenReturn(Uni.createFrom().item(List.of(userInstitution)));
+                .thenReturn(Uni.createFrom().item(userInfoResponse));
 
         given()
                 .when()
@@ -252,6 +261,7 @@ class UserControllerTest {
                 .statusCode(200);
 
         Mockito.verify(userService).retrieveBindings(any(), any(), any());
+
     }
 
     @Test


### PR DESCRIPTION
#### List of Changes

Changed implementation of api /users/{userId}/products using UserInfo collection instead of UserInstitution.

#### Motivation and Context

The api is used by the dashboard module to show the list of institutions associated with the user and the highest role they play for the institution's products. So I had to change the implementation to retrieve the data from the UserInfo collection, which provides faster and more concise access.

#### How Has This Been Tested?

local environment

#### Types of changes

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.