### PR TITLE
[SELC-4185] feat: refactor logic on retrieve user email based on userMailUuid instead of institutionId

### DIFF
--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/UserController.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/UserController.java
@@ -62,8 +62,7 @@ public class UserController {
     public Uni<UserResponse> getUserInfo(@PathParam(value = "id") String userId,
                                          @QueryParam(value = "institutionId") String institutionId,
                                          @QueryParam(value = "productId") String productId) {
-        return userService.retrievePerson(userId, productId, institutionId)
-                .map(user -> userMapper.toUserResponse(user, institutionId));
+        return userService.retrievePerson(userId, productId, institutionId);
     }
 
     @Operation(summary = "Retrieves products info and role which the user is enabled")

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/mapper/UserMapper.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/mapper/UserMapper.java
@@ -1,6 +1,8 @@
 package it.pagopa.selfcare.user.mapper;
 
-import it.pagopa.selfcare.user.controller.response.*;
+import it.pagopa.selfcare.user.controller.response.OnboardedProductResponse;
+import it.pagopa.selfcare.user.controller.response.UserNotificationResponse;
+import it.pagopa.selfcare.user.controller.response.UserResponse;
 import it.pagopa.selfcare.user.controller.response.product.InstitutionProducts;
 import it.pagopa.selfcare.user.controller.response.product.UserProductsResponse;
 import it.pagopa.selfcare.user.entity.UserInfo;
@@ -22,16 +24,16 @@ public interface UserMapper {
 
     @Mapping(source = "userResource.fiscalCode", target = "taxCode")
     @Mapping(source = "userResource.familyName", target = "surname")
-    @Mapping(target = "email", expression = "java(retrieveMailFromWorkContacts(userResource.getWorkContacts(), institutionId))")
-    UserResponse toUserResponse(UserResource userResource, String institutionId);
+    @Mapping(target = "email", expression = "java(retrieveMailFromWorkContacts(userResource.getWorkContacts(), userMailUuid))")
+    UserResponse toUserResponse(UserResource userResource, String userMailUuid);
     default String fromCertifiabletoString(CertifiableFieldResourceOfstring certifiableFieldResourceOfstring) {
         return certifiableFieldResourceOfstring.getValue();
     }
 
     @Named("retrieveMailFromWorkContacts")
-    default String retrieveMailFromWorkContacts(Map<String, WorkContactResource> map, String institutionId){
-        if(map!=null && !map.isEmpty() && map.containsKey(institutionId)){
-            return map.get(institutionId).getEmail().getValue();
+    default String retrieveMailFromWorkContacts(Map<String, WorkContactResource> map, String userMailUuid){
+        if(map!=null && !map.isEmpty() && map.containsKey(userMailUuid)){
+            return map.get(userMailUuid).getEmail().getValue();
         }
         return null;
     }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserService.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserService.java
@@ -6,9 +6,9 @@ import it.pagopa.selfcare.onboarding.common.PartyRole;
 import it.pagopa.selfcare.user.constant.OnboardedProductState;
 import it.pagopa.selfcare.user.controller.response.UserInstitutionResponse;
 import it.pagopa.selfcare.user.controller.response.UserProductResponse;
+import it.pagopa.selfcare.user.controller.response.UserResponse;
 import it.pagopa.selfcare.user.entity.UserInfo;
 import it.pagopa.selfcare.user.model.notification.UserNotificationToSend;
-import org.openapi.quarkus.user_registry_json.model.UserResource;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -19,7 +19,7 @@ public interface UserService {
 
     Multi<UserProductResponse> getUserProductsByInstitution(String institutionId);
 
-    Uni<UserResource> retrievePerson(String userId, String productId, String institutionId);
+    Uni<UserResponse> retrievePerson(String userId, String productId, String institutionId);
 
     Uni<UserInfo> retrieveBindings(String institutionId, String userId, String[] states);
 

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/controller/UserControllerTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/controller/UserControllerTest.java
@@ -9,6 +9,7 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.user.constant.OnboardedProductState;
 import it.pagopa.selfcare.user.controller.response.UserInstitutionResponse;
+import it.pagopa.selfcare.user.controller.response.UserResponse;
 import it.pagopa.selfcare.user.entity.UserInfo;
 import it.pagopa.selfcare.user.entity.UserInstitutionRole;
 import it.pagopa.selfcare.user.exception.InvalidRequestException;
@@ -19,16 +20,13 @@ import it.pagopa.selfcare.user.service.UserService;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.openapi.quarkus.user_registry_json.model.CertifiableFieldResourceOfLocalDate;
-import org.openapi.quarkus.user_registry_json.model.CertifiableFieldResourceOfstring;
 import org.openapi.quarkus.user_registry_json.model.MutableUserFieldsDto;
-import org.openapi.quarkus.user_registry_json.model.UserResource;
 
-import java.time.LocalDate;
 import java.util.*;
 
 import static io.restassured.RestAssured.given;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 
 @QuarkusTest
 @TestHTTPEndpoint(UserController.class)
@@ -97,13 +95,12 @@ class UserControllerTest {
     @Test
     @TestSecurity(user = "userJwt")
     void testGetUserInfoOk() {
-        UserResource userResource = new UserResource();
-        userResource.setId(UUID.randomUUID());
-        userResource.setFiscalCode("test");
-        userResource.setBirthDate(CertifiableFieldResourceOfLocalDate.builder().value(LocalDate.now()).build());
-        userResource.setEmail(CertifiableFieldResourceOfstring.builder().value("test@test.com").build());
-        userResource.setName(CertifiableFieldResourceOfstring.builder().value("testName").build());
-        userResource.setFamilyName(CertifiableFieldResourceOfstring.builder().value("testFamilyName").build());
+        UserResponse userResource = new UserResponse();
+        userResource.setId(UUID.randomUUID().toString());
+        userResource.setTaxCode("test");
+        userResource.setEmail("email");
+        userResource.setName("name");
+        userResource.setSurname("testFamilyName");
 
         Mockito.when(userService.retrievePerson(any(), any(), any()))
                 .thenReturn(Uni.createFrom().item(userResource));


### PR DESCRIPTION
…titutionId

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Refactor logic on retrieve user email based on userMailUuid instead of institutionId on two apis:
- users/emails
- users/{id}

#### Motivation and Context

New way of persisting user informations will be adopted on pdv, especially for what regards workContacts, as per now the workContacts is a map having the institutionId as key and the email as value. With the new method every mail will have a unique identifier generated when the user is added durign an onboarding.
The logic on upstram microservice has to be updated to retrieve the mail based on this unique identifier instead of the institutionId

#### How Has This Been Tested?

Runned application locally and verified the correct retrieval of the email

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.