### PR TITLE
[SELC-4184] feat: added api to process pdv emails' migration

### DIFF
--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/UserInfoController.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/UserInfoController.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 
-@Authenticated
+//@Authenticated
 @Path("/user-info")
 @RequiredArgsConstructor
 @Slf4j

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/UserInfoController.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/UserInfoController.java
@@ -2,8 +2,7 @@ package it.pagopa.selfcare.user.controller;
 
 import io.quarkus.security.Authenticated;
 import io.smallrye.mutiny.Uni;
-import it.pagopa.selfcare.user.controller.response.UsersNotificationResponse;
-import it.pagopa.selfcare.user.service.UserService;
+import it.pagopa.selfcare.user.service.UserInfoService;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import lombok.RequiredArgsConstructor;
@@ -16,21 +15,14 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 @Slf4j
 public class UserInfoController {
 
-    private final UserService userService;
+    private final UserInfoService userInfoService;
 
     @Operation(summary = "Retrieve all SC-User for DataLake filtered by optional productId")
     @GET
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Uni<UsersNotificationResponse> getUserInfo(@QueryParam(value = "page") @DefaultValue("0") Integer page,
-                                                      @QueryParam(value = "size") @DefaultValue("100") Integer size) {
-        return userService.findPaginatedUserNotificationToSend(size, page)
-                .map(userNotificationToSends -> {
-                    UsersNotificationResponse usersNotificationResponse = new UsersNotificationResponse();
-                    usersNotificationResponse.setUsers(userNotificationToSends.stream()
-                            .map(userMapper::toUserNotification)
-                            .toList());
-                    return usersNotificationResponse;
-                });
+    public Uni<Void> getUserInfo(@QueryParam(value = "page") @DefaultValue("0") Integer page,
+                                 @QueryParam(value = "size") @DefaultValue("100") Integer size) {
+        return userInfoService.updateUserEmail(size, page);
     }
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/UserInfoController.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/UserInfoController.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 
-//@Authenticated
+@Authenticated
 @Path("/user-info")
 @RequiredArgsConstructor
 @Slf4j
@@ -17,7 +17,7 @@ public class UserInfoController {
 
     private final UserInfoService userInfoService;
 
-    @Operation(summary = "Update users' workContacts in PDV using as key a random uuid and storing it into UserInstitution collection")
+    @Operation(summary = "Update users' workContacts in PDV using a random uuid as key and storing it into UserInstitution collection")
     @GET
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/UserInfoController.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/UserInfoController.java
@@ -17,12 +17,12 @@ public class UserInfoController {
 
     private final UserInfoService userInfoService;
 
-    @Operation(summary = "Retrieve all SC-User for DataLake filtered by optional productId")
+    @Operation(summary = "Update users' workContacts in PDV using as key a random uuid and storing it into UserInstitution collection")
     @GET
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Uni<Void> getUserInfo(@QueryParam(value = "page") @DefaultValue("0") Integer page,
-                                 @QueryParam(value = "size") @DefaultValue("100") Integer size) {
-        return userInfoService.updateUserEmail(size, page);
+    public Uni<Void> updateUsersEmails(@QueryParam(value = "page") @DefaultValue("0") Integer page,
+                                       @QueryParam(value = "size") @DefaultValue("100") Integer size) {
+        return userInfoService.updateUsersEmails(size, page);
     }
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/UserInfoController.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/UserInfoController.java
@@ -1,0 +1,36 @@
+package it.pagopa.selfcare.user.controller;
+
+import io.quarkus.security.Authenticated;
+import io.smallrye.mutiny.Uni;
+import it.pagopa.selfcare.user.controller.response.UsersNotificationResponse;
+import it.pagopa.selfcare.user.service.UserService;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+
+@Authenticated
+@Path("/user-info")
+@RequiredArgsConstructor
+@Slf4j
+public class UserInfoController {
+
+    private final UserService userService;
+
+    @Operation(summary = "Retrieve all SC-User for DataLake filtered by optional productId")
+    @GET
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Uni<UsersNotificationResponse> getUserInfo(@QueryParam(value = "page") @DefaultValue("0") Integer page,
+                                                      @QueryParam(value = "size") @DefaultValue("100") Integer size) {
+        return userService.findPaginatedUserNotificationToSend(size, page)
+                .map(userNotificationToSends -> {
+                    UsersNotificationResponse usersNotificationResponse = new UsersNotificationResponse();
+                    usersNotificationResponse.setUsers(userNotificationToSends.stream()
+                            .map(userMapper::toUserNotification)
+                            .toList());
+                    return usersNotificationResponse;
+                });
+    }
+}

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInfoService.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInfoService.java
@@ -6,5 +6,6 @@ import it.pagopa.selfcare.user.controller.response.UserInfoResponse;
 public interface UserInfoService {
 
     Uni<UserInfoResponse> findById(String userId);
+    Uni<Void> updateUserEmail(int page, int size);
 
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInfoService.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInfoService.java
@@ -4,8 +4,6 @@ import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.user.controller.response.UserInfoResponse;
 
 public interface UserInfoService {
-
     Uni<UserInfoResponse> findById(String userId);
-    Uni<Void> updateUserEmail(int page, int size);
-
+    Uni<Void> updateUsersEmails(int page, int size);
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInfoServiceDefault.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInfoServiceDefault.java
@@ -1,12 +1,18 @@
 package it.pagopa.selfcare.user.service;
 
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.user.controller.response.UserInfoResponse;
 import it.pagopa.selfcare.user.entity.UserInfo;
 import it.pagopa.selfcare.user.mapper.UserInfoMapper;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.openapi.quarkus.user_registry_json.api.UserApi;
+
+import java.util.stream.Collectors;
 
 @Slf4j
 @ApplicationScoped
@@ -14,11 +20,33 @@ import lombok.extern.slf4j.Slf4j;
 public class UserInfoServiceDefault implements UserInfoService {
 
     private final UserInfoMapper userInfoMapper;
+    private static final String USERS_FIELD_LIST_WITHOUT_FISCAL_CODE = "name,familyName,email,workContacts";
+
+    @RestClient
+    @Inject
+    private UserApi userRegistryApi;
 
     @Override
     public Uni<UserInfoResponse> findById(String userId) {
         Uni<UserInfo> userInfo = UserInfo.findById(userId);
         return userInfo.onItem().transform(userInfoMapper::toResponse);
+    }
+
+    @Override
+    public Uni<Void> updateUserEmail(int page, int size) {
+        Multi<UserInfo> userInfos = UserInfo.findAll().page(page, size).stream();
+        userInfos.onItem().transformToUni(userInfo -> userInstitution -> userRegistryApi
+                .findByIdUsingGET(USERS_FIELD_LIST_WITHOUT_FISCAL_CODE, userInfo.getUserId())
+                .map(userResource -> userResource.getWorkContacts()
+                        .values().stream().collect(Collectors.groupingBy(obj -> obj.getEmail().getValue()))
+                 )
+                .onItem().invoke(map -> userRegistryApi.updateUsingPATCH(userInfo.getUserId(), ))
+                .onItem().invoke(this::updateInstitution));
+        return Uni.createFrom().voidItem();
+    }
+
+    private void updateInstitution() {
+
     }
 
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInfoServiceDefault.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInfoServiceDefault.java
@@ -1,9 +1,11 @@
 package it.pagopa.selfcare.user.service;
 
+import io.quarkus.panache.common.Parameters;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.user.controller.response.UserInfoResponse;
 import it.pagopa.selfcare.user.entity.UserInfo;
+import it.pagopa.selfcare.user.entity.UserInstitution;
 import it.pagopa.selfcare.user.mapper.UserInfoMapper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -18,9 +20,9 @@ import org.openapi.quarkus.user_registry_json.model.WorkContactResource;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.function.Consumer;
 
 import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toMap;
 
 @Slf4j
 @ApplicationScoped
@@ -45,32 +47,37 @@ public class UserInfoServiceDefault implements UserInfoService {
     @Override
     public Uni<Void> updateUsersEmails(int page, int size) {
         Multi<UserInfo> userInfos = UserInfo.findAll().page(page, size).stream();
-        return userInfos.onItem().invoke(userInfo ->
+        return userInfos.onItem().transformToUni(userInfo ->
                 userRegistryApi.findByIdUsingGET(USERS_FIELD_LIST_WITHOUT_FISCAL_CODE, userInfo.getUserId())
-                .map(this::buildWorkContactsMap)
-                .invoke(userResource -> userRegistryApi.updateUsingPATCH(userInfo.getUserId(), MutableUserFieldsDto.builder().workContacts(userResource.getWorkContacts()).build())
-                        .onFailure().invoke(throwable -> log.error("Impossible to complete PDV patch for user {}. Error: {} ", userInfo.getUserId(), throwable.getMessage(), throwable)))
-                        .invoke(getUserResourceConsumer(userInfo)).replaceWith(Uni.createFrom().voidItem())
-                        .onFailure().invoke(throwable -> log.error("Impossible to update UserInstitution with userId {} and institutionId {}", userInfo.getUserId(), throwable.getMessage(), throwable)))
-                .onItem().ignoreAsUni();
+                        .map(this::buildWorkContactsMap)
+                        .onItem().transformToUni(this::updateUserInstitution)
+                        .onFailure()
+                        .invoke(throwable -> log.error("Impossible to complete PDV patch for user {}. Error: {} ", userInfo.getUserId(), throwable.getMessage(), throwable))
+        ).merge().toUni();
+    }
+
+    private Uni<Void> updateUserInstitution(UserResource userResource) {
+
+        String userId = userResource.getId().toString();
+        var filteredMap = userResource.getWorkContacts().entrySet().stream()
+                .filter(entry -> !entry.getKey().contains(EMAIL_UUID_PREFIX))
+                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        return userRegistryApi.updateUsingPATCH(userId, MutableUserFieldsDto.builder().workContacts(userResource.getWorkContacts()).build())
+                .onItem().invoke(() -> userResource.getWorkContacts().forEach((key, value) -> {
+                    if (key.contains(EMAIL_UUID_PREFIX)) {
+                        String institutionId = filteredMap.entrySet().stream().filter(el -> el.getValue().getEmail().getValue().equals(value.getEmail().getValue())).map(Map.Entry::getKey).findFirst().get();
+                        userService.updateUserInstitutionEmail(institutionId, userId, key);
+                    }
+                }))
+                .onFailure().invoke(throwable -> log.error("Impossible to update UserInstitution with userId {}", userId, throwable.getMessage(), throwable))
+                .replaceWith(Uni.createFrom().voidItem());
     }
 
     private UserResource buildWorkContactsMap(UserResource userResource) {
-        Map<String, List<WorkContactResource>> newMap = userResource.getWorkContacts().values().stream().collect(groupingBy(obj -> obj.getEmail().getValue()));
-        newMap.forEach((key, value) -> userResource.getWorkContacts().put(EMAIL_UUID_PREFIX.concat(UUID.randomUUID().toString()), value.get(0)));
+        Map<String, List<WorkContactResource>> mapGroupedByEmail = userResource.getWorkContacts().values().stream().collect(groupingBy(obj -> obj.getEmail().getValue()));
+        mapGroupedByEmail.forEach((key, value) -> userResource.getWorkContacts().put(EMAIL_UUID_PREFIX.concat(UUID.randomUUID().toString()), value.get(0)));
         return userResource;
-    }
-
-    private Consumer<UserResource> getUserResourceConsumer(UserInfo userInfo) {
-        return userResource -> {
-            var copiedMap = userResource.getWorkContacts();
-            userResource.getWorkContacts().forEach((key, value) -> {
-                if (key.contains(EMAIL_UUID_PREFIX)) {
-                    String institutionId = copiedMap.entrySet().stream().filter(el -> el.getValue().getEmail().getValue().equals(value.getEmail().getValue())).map(Map.Entry::getKey).findFirst().get();
-                    userService.updateUserInstitutionEmail(institutionId, userInfo.getUserId(), key);
-                }
-            });
-        };
     }
 
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionService.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionService.java
@@ -31,6 +31,8 @@ public interface UserInstitutionService {
 
     Uni<Long> updateUserCreatedAtByInstitutionAndProduct(String institutionId, List<String> userIds, String productId, LocalDateTime createdAt);
 
+    Uni<Long> updateUserInstitutionEmail(String institutionId, String userId, String uuidEmail);
+
     Uni<List<UserInstitution>> retrieveFilteredUserInstitution(Map<String, Object> queryParameter);
 
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionServiceDefault.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionServiceDefault.java
@@ -96,6 +96,14 @@ public class UserInstitutionServiceDefault implements UserInstitutionService {
     }
 
     @Override
+    public Uni<Long> updateUserInstitutionEmail(String institutionId, String userId, String uuidEmail) {
+        Map<String, Object> filtersMap = UserInstitutionFilter.builder().userId(userId).institutionId(institutionId).build().constructMap();
+        Map<String, Object> fieldToUpdateMap = Map.of(UserInstitution.Fields.userMailUuid.name(), uuidEmail);
+        return UserInstitution.update(queryUtils.buildUpdateDocument(fieldToUpdateMap))
+                .where(queryUtils.buildQueryDocument(filtersMap, USER_INSTITUTION_COLLECTION));
+    }
+
+    @Override
     public Multi<UserInstitution> findAllWithFilter(Map<String, Object> queryParameter) {
         Document query = queryUtils.buildQueryDocument(queryParameter, USER_INSTITUTION_COLLECTION);
         log.debug("Query: {}", query);

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserService.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserService.java
@@ -34,5 +34,8 @@ public interface UserService {
     Uni<List<UserNotificationToSend>> findPaginatedUserNotificationToSend(Integer size, Integer page, String productId);
 
     Uni<List<UserInstitutionResponse>> findAllByIds(List<String> userIds);
+
     Uni<Void> updateUserProductCreatedAt(String institutionId, List<String> userIds, String productId, LocalDateTime createdAt);
+
+    Uni<Void> updateUserInstitutionEmail(String institutionId, String userId, String uuidEmail);
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserServiceImpl.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserServiceImpl.java
@@ -171,6 +171,17 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    public Uni<Void> updateUserInstitutionEmail(String institutionId, String userId, String uuidEmail) {
+        return userInstitutionService.updateUserInstitutionEmail(institutionId, userId, uuidEmail)
+                .onItem().transformToUni(aLong -> {
+                    if (aLong < 1) {
+                        return Uni.createFrom().failure(new ResourceNotFoundException(USERS_TO_UPDATE_NOT_FOUND.getMessage()));
+                    }
+                    return Uni.createFrom().nullItem();
+                });
+    }
+
+    @Override
     public Uni<List<UserNotificationToSend>> findPaginatedUserNotificationToSend(Integer size, Integer page, String productId) {
         Map<String, Object> queryParameter;
         if (StringUtils.isNotBlank(productId)) {

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/controller/UserInfoControllerTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/controller/UserInfoControllerTest.java
@@ -1,0 +1,58 @@
+package it.pagopa.selfcare.user.controller;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import io.restassured.http.ContentType;
+import io.smallrye.mutiny.Uni;
+import it.pagopa.selfcare.user.service.UserInfoService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static io.restassured.RestAssured.given;
+import static org.mockito.ArgumentMatchers.anyInt;
+
+@QuarkusTest
+@TestHTTPEndpoint(UserInfoController.class)
+class UserInfoControllerTest {
+
+    @InjectMock
+    private UserInfoService userInfoService;
+
+    /**
+     * Method under test: {@link UserInfoController#updateUsersEmails(Integer, Integer)}}
+     */
+    @Test
+    @TestSecurity(user = "userJwt")
+    void updateUsersEmails() {
+
+        int size = 1, page = 1;
+
+        Mockito.when(userInfoService.updateUsersEmails(anyInt(), anyInt()))
+                .thenReturn(Uni.createFrom().nullItem());
+
+        given()
+                .when()
+                .contentType(ContentType.JSON)
+                .get("?size=" + size +"&page=" + page)
+                .then()
+                .statusCode(204);
+    }
+
+    /**
+     * Method under test: {@link UserInfoController#updateUsersEmails(Integer, Integer)}}
+     */
+    @Test
+    void updateUsersEmailsNotAuthorized() {
+
+        given().when()
+                .contentType(ContentType.JSON)
+                .queryParam("page", 0)
+                .queryParam("size", 100)
+                .get()
+                .then()
+                .statusCode(401);
+    }
+
+}

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserInfoServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserInfoServiceTest.java
@@ -2,18 +2,30 @@ package it.pagopa.selfcare.user.service;
 
 import io.quarkus.mongodb.panache.reactive.ReactivePanacheQuery;
 import io.quarkus.panache.mock.PanacheMock;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.mongodb.MongoTestResource;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import it.pagopa.selfcare.user.controller.response.UserInfoResponse;
 import it.pagopa.selfcare.user.entity.UserInfo;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.openapi.quarkus.user_registry_json.model.UserResource;
+import org.openapi.quarkus.user_registry_json.model.WorkContactResource;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 
 @QuarkusTest
@@ -23,6 +35,36 @@ class UserInfoServiceTest {
     @Inject
     private UserInfoServiceDefault userInfoService;
 
+    @Inject
+    UserRegistryService userRegistryService;
+
+    @InjectMock
+    private UserService userService;
+
+    @RestClient
+    @InjectMock
+    private org.openapi.quarkus.user_registry_json.api.UserApi userRegistryApi;
+
+    private static UserResource userResource;
+    private static final String USERS_FIELD_LIST_WITHOUT_FISCAL_CODE = "name,familyName,email,workContacts";
+
+    static {
+        userResource = new org.openapi.quarkus.user_registry_json.model.UserResource();
+        userResource.setId(UUID.randomUUID());
+        org.openapi.quarkus.user_registry_json.model.CertifiableFieldResourceOfstring certifiedName = new org.openapi.quarkus.user_registry_json.model.CertifiableFieldResourceOfstring();
+        certifiedName.setValue("name");
+        userResource.setName(certifiedName);
+        userResource.setFamilyName(certifiedName);
+        userResource.setFiscalCode("taxCode");
+        org.openapi.quarkus.user_registry_json.model.CertifiableFieldResourceOfstring certifiedEmail = new org.openapi.quarkus.user_registry_json.model.CertifiableFieldResourceOfstring();
+        certifiedEmail.setValue("test@test.it");
+        org.openapi.quarkus.user_registry_json.model.WorkContactResource workContactResource = new org.openapi.quarkus.user_registry_json.model.WorkContactResource();
+        workContactResource.setEmail(certifiedEmail);
+        userResource.setEmail(certifiedEmail);
+        Map<String, WorkContactResource> workContactsMap = new HashMap<>();
+        workContactsMap.put("institutionId", workContactResource);
+        userResource.setWorkContacts(workContactsMap);
+    }
 
     @Test
     void findByUserId() {
@@ -35,6 +77,24 @@ class UserInfoServiceTest {
                 .thenReturn(query);
         Uni<UserInfoResponse> response = userInfoService.findById(userId);
         Assertions.assertNotNull(response);
+    }
+
+    @Test
+    void updateUserEmails() {
+        final int size = 1, page = 1;
+        var userInfo = createDummyUserInfo();
+        PanacheMock.mock(UserInfo.class);
+        ReactivePanacheQuery query = Mockito.mock(ReactivePanacheQuery.class);
+        when(UserInfo.findAll())
+                .thenReturn(query);
+        when(query.page(anyInt(), anyInt())).thenReturn(query);
+        when(query.stream()).thenReturn(Multi.createFrom().items(userInfo));
+        when(userService.updateUserInstitutionEmail(any(), any(), any())).thenReturn(Uni.createFrom().voidItem());
+        when(userRegistryApi.updateUsingPATCH(any(), any())).thenReturn(Uni.createFrom().item(Response.accepted().build()));
+        when(userRegistryApi.findByIdUsingGET(USERS_FIELD_LIST_WITHOUT_FISCAL_CODE, "userId")).thenReturn(Uni.createFrom().item(userResource));
+        UniAssertSubscriber<Void> subscriber = userInfoService.updateUsersEmails(size, page)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        Assertions.assertNotNull(subscriber.assertCompleted().awaitItem());
     }
 
     private UserInfo createDummyUserInfo() {

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserInstitutionServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserInstitutionServiceTest.java
@@ -21,10 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static io.smallrye.common.constraint.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -206,6 +203,21 @@ class UserInstitutionServiceTest {
                 .thenReturn(update);
         when(update.where(any())).thenReturn(Uni.createFrom().item(1L));
         UniAssertSubscriber<Long> subscriber = userInstitutionService.updateUserCreatedAtByInstitutionAndProduct(institutionId, List.of(userId), productId, LocalDateTime.now())
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.assertCompleted().assertItem(1L);
+    }
+
+    @Test
+    void updateUserInstitutionEmail() {
+        final String userId = "userId";
+        final String institutionId = "institutionId";
+        final String uuidEmail = UUID.randomUUID().toString();
+        PanacheMock.mock(UserInstitution.class);
+        ReactivePanacheUpdate update = Mockito.mock(ReactivePanacheUpdate.class);
+        when(UserInstitution.update(any(Document.class)))
+                .thenReturn(update);
+        when(update.where(any())).thenReturn(Uni.createFrom().item(1L));
+        UniAssertSubscriber<Long> subscriber = userInstitutionService.updateUserInstitutionEmail(institutionId, userId, uuidEmail)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         subscriber.assertCompleted().assertItem(1L);
     }

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
@@ -408,6 +408,20 @@ class UserServiceTest {
     }
 
     @Test
+    void updateUserInstitutionEmailNotFound(){
+        String uuidEmail = UUID.randomUUID().toString();
+        when(userInstitutionService
+                .updateUserInstitutionEmail("institutionId", "userId", uuidEmail))
+                .thenReturn(Uni.createFrom().item(0L));
+
+        UniAssertSubscriber<Void> subscriber = userService
+                .updateUserInstitutionEmail("institutionId", "userId", uuidEmail)
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create());
+        subscriber.assertCompleted();
+    }
+
+    @Test
     void findPaginatedUserNotificationToSend() {
         when(userInstitutionService.paginatedFindAllWithFilter(any(), any(), any()))
                 .thenReturn(Multi.createFrom().item(userInstitution));

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
@@ -394,6 +394,20 @@ class UserServiceTest {
     }
 
     @Test
+    void updateUserInstitutionEmail(){
+        String uuidEmail = UUID.randomUUID().toString();
+        when(userInstitutionService
+                .updateUserInstitutionEmail("institutionId", "userId", uuidEmail))
+                .thenReturn(Uni.createFrom().item(1L));
+
+        UniAssertSubscriber<Void> subscriber = userService
+                .updateUserInstitutionEmail("institutionId", "userId", uuidEmail)
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create());
+        subscriber.assertCompleted();
+    }
+
+    @Test
     void findPaginatedUserNotificationToSend() {
         when(userInstitutionService.paginatedFindAllWithFilter(any(), any(), any()))
                 .thenReturn(Multi.createFrom().item(userInstitution));

--- a/infra/container_apps/user-ms/env/dev/terraform.tfvars
+++ b/infra/container_apps/user-ms/env/dev/terraform.tfvars
@@ -24,6 +24,7 @@ app_settings = [
 secrets_names = [
   "jwt-public-key",
   "mongodb-connection-string",
-  "appinsights-instrumentation-key"
+  "appinsights-instrumentation-key",
+
 ]
 


### PR DESCRIPTION
#### List of Changes

Added API to process PDV Patch and modify structure of existing map of workContacts

#### Motivation and Context

This API and all relative business logic has been added to reduce size of each document stored into PDV database. Instead to have a map with an entry fo each institution into workContact's node, with this implementation we will have an entry for each email used into onboarding process.

#### How Has This Been Tested?

I have run ms locally and tested the operation with a specific user.

