### PR TITLE
[SELC-4187] Feat: Added API to create or update User on userRegistry and UserInstitution collection

### DIFF
--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/constant/CollectionUtil.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/constant/CollectionUtil.java
@@ -10,4 +10,6 @@ public class CollectionUtil {
     public static final String USER_INFO_COLLECTION = "userInfo";
     public static final String CURRENT = ".$.";
     public static final String CURRENT_ANY = ".$[].";
+
+    public static final String MAIL_ID_PREFIX = "ID_MAIL#";
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/request/CreateUserDto.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/request/CreateUserDto.java
@@ -1,0 +1,52 @@
+package it.pagopa.selfcare.user.controller.request;
+
+import it.pagopa.selfcare.onboarding.common.PartyRole;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class CreateUserDto {
+
+    @NotEmpty(message = "institutionId is required")
+    private String institutionId;
+
+    @NotNull(message = "user is required")
+    private User user;
+
+    @NotNull(message = "product is required")
+    private Product product;
+
+    private String institutionDescription;
+    private String institutionRootName;
+
+    @Data
+    public static class User {
+        private String birthDate;
+
+        @NotEmpty(message = "email is required")
+        private String familyName;
+
+        @NotEmpty(message = "fiscalCode is required")
+        private String fiscalCode;
+
+        @NotEmpty(message = "name is required")
+        private String name;
+
+        @NotEmpty(message = "email is required")
+        private String institutionEmail;
+    }
+
+    @Data
+    public static class Product {
+
+        @NotEmpty(message = "productId is required")
+        private String productId;
+
+        @NotNull(message = "role is required")
+        private PartyRole role;
+
+        private String tokenId;
+        private String productRole;
+    }
+}

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/entity/UserInstitution.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/entity/UserInstitution.java
@@ -7,6 +7,7 @@ import lombok.EqualsAndHashCode;
 import lombok.experimental.FieldNameConstants;
 import org.bson.types.ObjectId;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @EqualsAndHashCode(callSuper = true)
@@ -20,7 +21,7 @@ public class UserInstitution extends ReactivePanacheMongoEntity {
     private String institutionId;
     private String institutionDescription;
     private String institutionRootName;
-    private List<OnboardedProduct> products;
+    private List<OnboardedProduct> products = new ArrayList<>();
     private String userMailUuid;
 
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/entity/filter/UserInstitutionFilter.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/entity/filter/UserInstitutionFilter.java
@@ -15,12 +15,14 @@ public class UserInstitutionFilter {
 
     private final Object userId;
     private final Object institutionId;
+    private final Object userMailUuid;
     private final Object institutionDescription;
 
     @Getter
     @AllArgsConstructor
     public enum UserInstitutionFilterEnum{
         USER_ID(UserInstitution.Fields.userId.name()),
+        USER_MAIL_ID(UserInstitution.Fields.userMailUuid.name()),
         INSTITUTION_ID(UserInstitution.Fields.institutionId.name()),
         INSTITUTION_DESCRIPTION(UserInstitution.Fields.institutionDescription.name());
 
@@ -31,6 +33,7 @@ public class UserInstitutionFilter {
         Map<String, Object> map = new HashMap<>();
 
         map.put(USER_ID.getDescription(), userId);
+        map.put(USER_MAIL_ID.getDescription(), userMailUuid);
         map.put(INSTITUTION_ID.getDescription(), institutionId);
         map.put(INSTITUTION_DESCRIPTION.getDescription(), institutionDescription);
 

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/mapper/OnboardedProductMapper.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/mapper/OnboardedProductMapper.java
@@ -1,8 +1,10 @@
 package it.pagopa.selfcare.user.mapper;
 
+import it.pagopa.selfcare.user.controller.request.CreateUserDto;
 import it.pagopa.selfcare.user.controller.response.OnboardedProductResponse;
 import it.pagopa.selfcare.user.entity.OnboardedProduct;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 import java.util.List;
 
@@ -10,6 +12,12 @@ import java.util.List;
 public interface OnboardedProductMapper {
 
     OnboardedProductResponse toResponse(OnboardedProduct onboardedProduct);
+
     List<OnboardedProductResponse> toList(List<OnboardedProduct> onboardedProducts);
 
+    @Mapping(target = "status",  expression = "java(it.pagopa.selfcare.user.constant.OnboardedProductState.ACTIVE)")
+    @Mapping(target = "env",  expression = "java(it.pagopa.selfcare.onboarding.common.Env.ROOT)")
+    @Mapping(target = "createdAt", expression = "java(java.time.LocalDateTime.now())")
+    @Mapping(target = "updatedAt", expression = "java(java.time.LocalDateTime.now())")
+    OnboardedProduct toEntity(CreateUserDto.Product product);
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/mapper/UserInstitutionMapper.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/mapper/UserInstitutionMapper.java
@@ -1,6 +1,8 @@
 package it.pagopa.selfcare.user.mapper;
 
+import it.pagopa.selfcare.user.controller.request.CreateUserDto;
 import it.pagopa.selfcare.user.controller.response.UserInstitutionResponse;
+import it.pagopa.selfcare.user.entity.OnboardedProduct;
 import it.pagopa.selfcare.user.entity.UserInstitution;
 import org.bson.types.ObjectId;
 import org.mapstruct.Mapper;
@@ -13,9 +15,22 @@ public interface UserInstitutionMapper {
     @Mapping(target = "id", expression = "java(objectIdToString(userInstitution.getId()))")
     UserInstitutionResponse toResponse(UserInstitution userInstitution);
 
-
     @Named("objectIdToString")
     default String objectIdToString(ObjectId objectId) {
         return objectId.toHexString();
     }
+
+    @Mapping(source = "userId", target = "userId")
+    @Mapping(source = "createUserDto.institutionId", target = "institutionId")
+    @Mapping(source = "createUserDto.institutionDescription", target = "institutionDescription")
+    @Mapping(source = "createUserDto.institutionRootName", target = "institutionRootName")
+    @Mapping(source = "userMailUuid", target = "userMailUuid")
+    @Mapping(target = "products",  expression = "java(java.util.List.of(toOnboardedProduct(createUserDto.getProduct())))")
+    UserInstitution toEntity(CreateUserDto createUserDto, String userId, String userMailUuid);
+
+    @Mapping(target = "status",  expression = "java(it.pagopa.selfcare.user.constant.OnboardedProductState.ACTIVE)")
+    @Mapping(target = "env",  expression = "java(it.pagopa.selfcare.onboarding.common.Env.ROOT)")
+    @Mapping(target = "createdAt", expression = "java(java.time.LocalDateTime.now())")
+    @Mapping(target = "updatedAt", expression = "java(java.time.LocalDateTime.now())")
+    OnboardedProduct toOnboardedProduct(CreateUserDto.Product product);
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/mapper/UserMapper.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/mapper/UserMapper.java
@@ -1,9 +1,7 @@
 package it.pagopa.selfcare.user.mapper;
 
-import it.pagopa.selfcare.user.controller.response.OnboardedProductResponse;
-import it.pagopa.selfcare.user.controller.response.UserDetailResponse;
-import it.pagopa.selfcare.user.controller.response.UserNotificationResponse;
-import it.pagopa.selfcare.user.controller.response.UserResponse;
+import it.pagopa.selfcare.user.controller.request.CreateUserDto;
+import it.pagopa.selfcare.user.controller.response.*;
 import it.pagopa.selfcare.user.controller.response.product.InstitutionProducts;
 import it.pagopa.selfcare.user.controller.response.product.UserProductsResponse;
 import it.pagopa.selfcare.user.entity.UserInfo;
@@ -11,10 +9,9 @@ import it.pagopa.selfcare.user.model.notification.UserNotificationToSend;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
-import org.openapi.quarkus.user_registry_json.model.CertifiableFieldResourceOfstring;
-import org.openapi.quarkus.user_registry_json.model.UserResource;
-import org.openapi.quarkus.user_registry_json.model.WorkContactResource;
+import org.openapi.quarkus.user_registry_json.model.*;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
@@ -24,10 +21,16 @@ public interface UserMapper {
     UserNotificationResponse toUserNotification(UserNotificationToSend user);
 
     @Mapping(source = "userResource.fiscalCode", target = "taxCode")
-    @Mapping(source = "userResource.familyName", target = "surname")
+    @Mapping(source = "userResource.familyName", target = "surname", qualifiedByName = "fromCertifiableString")
+    @Mapping(source = "userResource.name", target = "name", qualifiedByName = "fromCertifiableString")
     @Mapping(target = "email", expression = "java(retrieveMailFromWorkContacts(userResource.getWorkContacts(), userMailUuid))")
     UserResponse toUserResponse(UserResource userResource, String userMailUuid);
-    default String fromCertifiabletoString(CertifiableFieldResourceOfstring certifiableFieldResourceOfstring) {
+
+    @Named("fromCertifiableString")
+    default String fromCertifiableString(CertifiableFieldResourceOfstring certifiableFieldResourceOfstring) {
+        if(certifiableFieldResourceOfstring == null) {
+            return null;
+        }
         return certifiableFieldResourceOfstring.getValue();
     }
 
@@ -66,4 +69,28 @@ public interface UserMapper {
         return response;
     }
 
+    MutableUserFieldsDto toMutableUserFieldsDto(UserResource userResource);
+
+    @Mapping(source = "user.birthDate", target = "birthDate", qualifiedByName = "toCertifiableLocalDate")
+    @Mapping(source = "user.familyName", target = "familyName",  qualifiedByName = "toCertifiableString")
+    @Mapping(source = "user.name", target = "name",  qualifiedByName = "toCertifiableString")
+    @Mapping(source = "user.fiscalCode", target = "fiscalCode")
+    @Mapping(source = "workContactResource", target = "workContacts")
+    SaveUserDto toSaveUserDto(CreateUserDto.User user, Map<String, WorkContactResource> workContactResource);
+
+    @Named("toCertifiableLocalDate")
+    default CertifiableFieldResourceOfLocalDate toLocalTime(String time) {
+        var tmp = new CertifiableFieldResourceOfLocalDate();
+        tmp.setValue(LocalDate.parse(time));
+        tmp.setCertification(CertifiableFieldResourceOfLocalDate.CertificationEnum.NONE);
+        return tmp;
+    }
+
+    @Named("toCertifiableString")
+    default CertifiableFieldResourceOfstring toCertString(String value) {
+        var tmp = new CertifiableFieldResourceOfstring();
+        tmp.setValue(value);
+        tmp.setCertification(CertifiableFieldResourceOfstring.CertificationEnum.NONE);
+        return tmp;
+    }
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionService.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionService.java
@@ -33,4 +33,7 @@ public interface UserInstitutionService {
 
     Uni<List<UserInstitution>> retrieveFilteredUserInstitution(Map<String, Object> queryParameter);
 
+    Uni<UserInstitution> findByUserIdAndInstitutionId(String userId, String institutionId);
+
+    Uni<Void> persistOrUpdate(UserInstitution... userInstitution);
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionServiceDefault.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionServiceDefault.java
@@ -11,7 +11,6 @@ import it.pagopa.selfcare.user.entity.UserInstitution;
 import it.pagopa.selfcare.user.entity.filter.OnboardedProductFilter;
 import it.pagopa.selfcare.user.entity.filter.UserInstitutionFilter;
 import it.pagopa.selfcare.user.mapper.UserInstitutionMapper;
-import it.pagopa.selfcare.user.util.GeneralUtils;
 import it.pagopa.selfcare.user.util.QueryUtils;
 import it.pagopa.selfcare.user.util.UserUtils;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -121,6 +120,19 @@ public class UserInstitutionServiceDefault implements UserInstitutionService {
         Document query = queryUtils.buildQueryDocument(queryParameter, USER_INSTITUTION_COLLECTION);
         return runUserInstitutionFindQuery(query, null).list();
     }
+
+    @Override
+    public Uni<UserInstitution> findByUserIdAndInstitutionId(String userId, String institutionId) {
+        Map<String, Object> userInstitutionFilterMap = UserInstitutionFilter.builder().userId(userId).institutionId(institutionId).build().constructMap();
+        Document query = queryUtils.buildQueryDocument(userInstitutionFilterMap, USER_INSTITUTION_COLLECTION);
+        return runUserInstitutionFindQuery(query, null).firstResult();
+    }
+
+    @Override
+    public Uni<Void> persistOrUpdate(UserInstitution... userInstitution) {
+        return UserInstitution.persistOrUpdate(userInstitution);
+    }
+
 
     private boolean productFilterIsEmpty(Map<String, Object> filterMap) {
         return !filterMap.containsKey(PRODUCT_ID.getChild())

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserService.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserService.java
@@ -4,10 +4,10 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
 import it.pagopa.selfcare.user.constant.OnboardedProductState;
+import it.pagopa.selfcare.user.controller.request.CreateUserDto;
 import it.pagopa.selfcare.user.model.LoggedUser;
 import it.pagopa.selfcare.user.controller.response.UserInstitutionResponse;
 import it.pagopa.selfcare.user.controller.response.UserProductResponse;
-import it.pagopa.selfcare.user.controller.response.UserResponse;
 import it.pagopa.selfcare.user.entity.UserInfo;
 import it.pagopa.selfcare.user.model.notification.UserNotificationToSend;
 import org.openapi.quarkus.user_registry_json.model.UserResource;
@@ -21,7 +21,7 @@ public interface UserService {
 
     Multi<UserProductResponse> getUserProductsByInstitution(String institutionId);
 
-    Uni<UserResponse> retrievePerson(String userId, String productId, String institutionId);
+    Uni<UserResource> retrievePerson(String userId, String productId, String institutionId);
 
     Uni<UserInfo> retrieveBindings(String institutionId, String userId, String[] states);
 
@@ -36,6 +36,7 @@ public interface UserService {
     Uni<List<UserNotificationToSend>> findPaginatedUserNotificationToSend(Integer size, Integer page, String productId);
 
     Uni<List<UserInstitutionResponse>> findAllByIds(List<String> userIds);
+
     Uni<Void> updateUserProductCreatedAt(String institutionId, List<String> userIds, String productId, LocalDateTime createdAt);
 
     Uni<UserResource> getUserById(String userId);
@@ -44,4 +45,5 @@ public interface UserService {
 
     Uni<Void> updateUserProductStatus(String userId, String institutionId, String productId, OnboardedProductState status, LoggedUser loggedUser);
 
+    Uni<Void> createOrUpdateUser(CreateUserDto userDto);
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserServiceImpl.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserServiceImpl.java
@@ -4,14 +4,11 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
-import it.pagopa.selfcare.product.entity.Product;
 import it.pagopa.selfcare.product.service.ProductService;
 import it.pagopa.selfcare.user.constant.OnboardedProductState;
-import it.pagopa.selfcare.user.mapper.UserMapper;
-import it.pagopa.selfcare.user.model.LoggedUser;
+import it.pagopa.selfcare.user.controller.request.CreateUserDto;
 import it.pagopa.selfcare.user.controller.response.UserInstitutionResponse;
 import it.pagopa.selfcare.user.controller.response.UserProductResponse;
-import it.pagopa.selfcare.user.controller.response.UserResponse;
 import it.pagopa.selfcare.user.entity.UserInfo;
 import it.pagopa.selfcare.user.entity.UserInstitution;
 import it.pagopa.selfcare.user.entity.filter.OnboardedProductFilter;
@@ -20,6 +17,8 @@ import it.pagopa.selfcare.user.exception.InvalidRequestException;
 import it.pagopa.selfcare.user.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.user.mapper.OnboardedProductMapper;
 import it.pagopa.selfcare.user.mapper.UserInstitutionMapper;
+import it.pagopa.selfcare.user.mapper.UserMapper;
+import it.pagopa.selfcare.user.model.LoggedUser;
 import it.pagopa.selfcare.user.model.notification.PrepareNotificationData;
 import it.pagopa.selfcare.user.model.notification.UserNotificationToSend;
 import it.pagopa.selfcare.user.util.UserUtils;
@@ -32,13 +31,12 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.openapi.quarkus.user_registry_json.api.UserApi;
 import org.openapi.quarkus.user_registry_json.model.UserResource;
 import org.openapi.quarkus.user_registry_json.model.UserSearchDto;
+import org.openapi.quarkus.user_registry_json.model.WorkContactResource;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
+import static it.pagopa.selfcare.user.constant.CollectionUtil.MAIL_ID_PREFIX;
 import static it.pagopa.selfcare.user.constant.CustomError.*;
 import static it.pagopa.selfcare.user.util.GeneralUtils.formatQueryParameterList;
 import static it.pagopa.selfcare.user.util.UserUtils.VALID_USER_PRODUCT_STATES_FOR_NOTIFICATION;
@@ -53,13 +51,14 @@ public class UserServiceImpl implements UserService {
     private UserApi userRegistryApi;
 
     private final UserMapper userMapper;
-    private final OnboardedProductMapper onboardedProductMapper;
-    private final UserUtils userUtils;
-    private final UserInstitutionService userInstitutionService;
     private final UserInstitutionMapper userInstitutionMapper;
+    private final OnboardedProductMapper onboardedProductMapper;
 
-    private final UserNotificationService userNotificationService;
+    private final UserUtils userUtils;
+
     private final ProductService productService;
+    private final UserInstitutionService userInstitutionService;
+    private final UserNotificationService userNotificationService;
 
     private static final String WORK_CONTACTS = "workContacts";
 
@@ -119,7 +118,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public Uni<UserResponse> retrievePerson(String userId, String productId, String institutionId) {
+    public Uni<UserResource> retrievePerson(String userId, String productId, String institutionId) {
         var userInstitutionFilters = UserInstitutionFilter.builder().userId(userId).institutionId(institutionId).build().constructMap();
         var productFilters = OnboardedProductFilter.builder().productId(productId).build().constructMap();
         Map<String, Object> queryParameter = userUtils.retrieveMapForFilter(userInstitutionFilters, productFilters);
@@ -128,8 +127,7 @@ public class UserServiceImpl implements UserService {
                     log.error(String.format(USER_NOT_FOUND_ERROR.getMessage(), userId));
                     return new ResourceNotFoundException(String.format(USER_NOT_FOUND_ERROR.getMessage(), userId), USER_NOT_FOUND_ERROR.getCode());
                 })
-                .onItem().transformToUni(userInstitution -> userRegistryApi.findByIdUsingGET(USERS_WORKS_FIELD_LIST, userInstitution.getUserId())
-                        .map(userResource -> userMapper.toUserResponse(userResource, userInstitution.getUserMailUuid())))
+                .onItem().transformToUni(userInstitution -> userRegistryApi.findByIdUsingGET(USERS_WORKS_FIELD_LIST, userInstitution.getUserId()))
                 .onFailure(UserUtils::checkIfNotFoundException).transform(t -> new ResourceNotFoundException(String.format(USER_NOT_FOUND_ERROR.getMessage(), userId), USER_NOT_FOUND_ERROR.getCode()));
     }
 
@@ -212,7 +210,7 @@ public class UserServiceImpl implements UserService {
                         .replaceWith(prepareNotificationData))
                 .onItem().transform(prepareNotificationData -> userUtils.buildUserNotificationToSend(prepareNotificationData.getUserInstitution(), prepareNotificationData.getUserResource(), productId, status))
                 .onItem().call(userNotificationToSend -> userNotificationService.sendKafkaNotification(userNotificationToSend, userId))
-                .onFailure().invoke(x -> log.error("Error during update user status for userId: {}, institutionId: {}, productId:{} -> exception: {}", userId, institutionId, productId, x.getMessage(), x))
+                .onFailure().invoke(throwable -> log.error("Error during update user status for userId: {}, institutionId: {}, productId:{} -> exception: {}", userId, institutionId, productId, throwable.getMessage(), throwable))
                 .replaceWithVoid();
     }
 
@@ -271,5 +269,91 @@ public class UserServiceImpl implements UserService {
                         })
                         .orElseThrow(() -> new ResourceNotFoundException(""))
                 );
+    }
+
+    /**
+     * The createOrUpdateUser method is a method that either creates a new user or updates an existing one based on the provided CreateUserDto object.
+     * The method starts by calling the searchUsingPOST method on the userRegistryApi object, this is an asynchronous operation that searches for a user in the user registry.
+     * If the search operation fails with a UserNotFoundException, it recovers by returning a Uni that fails with a ResourceNotFoundException.
+     * This is a way of transforming one type of exception into another.
+     * If the search operation is successful, it call method to Update user on userRegistry and UserInstitution collection.
+     * In case of previously fail with ResourceNotFoundException, it recovers by calling the method to create new User on userRegsitry and UserInstitution
+     * collection.
+     * Finally, if any operation fails, it logs an error message and returns a Uni that emits a failure.
+     */
+     @Override
+    public Uni<Void> createOrUpdateUser(CreateUserDto userDto) {
+        return searchUserByFiscalCode(userDto.getUser().getFiscalCode())
+                .onFailure(UserUtils::isUserNotFoundExceptionOnUserRegistry).recoverWithUni(throwable -> Uni.createFrom().failure(new ResourceNotFoundException(throwable.getMessage())))
+                .onItem().transformToUni(userResource -> updateUserOnUserRegistryAndUserInstitution(userResource, userDto))
+                .onFailure(ResourceNotFoundException.class).recoverWithUni(throwable -> createUserOnUserRegistryAndUserInstitution(userDto))
+                .onFailure().invoke(exception -> log.error("Error during retrieve user from userRegistry: {} ", exception.getMessage(), exception));
+    }
+
+    /**
+     * The updateUserOnUserRegistryAndUserInstitution method is a method that updates a user's information on both the user registry and the user institution.
+     * The method retrieves the mailUuid from the user's work contacts. If it doesn't exist, it generates a new one.
+     * Next, it builds a workContact object using the institution email from the userDto object and adds it to the user's work contacts using the mailUuid as the key.
+     * The method then attempts to update the user on the user registry using a PATCH request.
+     * After the user registry update, the method attempts to find the related userInstitution by the user ID and institution ID from the userDto object.
+     * Once the userInstitution model is updated or created, attempts to persist the user institution.
+     * If any of the operations fail, the method logs an error message and returns a Uni that emits a failure.
+     */
+    private Uni<Void> updateUserOnUserRegistryAndUserInstitution(UserResource userResource, CreateUserDto userDto) {
+        log.info("Updating user on userRegistry and userInstitution");
+        String mailUuid = userUtils.getMailUuidFromMail(userResource.getWorkContacts(), userDto.getUser().getInstitutionEmail())
+                .orElse(MAIL_ID_PREFIX + UUID.randomUUID());
+
+        var workContact = UserUtils.buildWorkContact(userDto.getUser().getInstitutionEmail());
+        userResource.getWorkContacts().put(mailUuid, workContact);
+
+        return userRegistryApi.updateUsingPATCH(userResource.getId().toString(), userMapper.toMutableUserFieldsDto(userResource))
+                .onFailure().invoke(exception -> log.error("Error during update user on userRegistry: {} ", exception.getMessage(), exception))
+                .onItem().invoke(response -> log.info("User with id {} updated on userRegistry", userResource.getId()))
+                .onItem().transformToUni(response -> userInstitutionService.findByUserIdAndInstitutionId(userResource.getId().toString(), userDto.getInstitutionId()))
+                .onItem().transform(userInstitution -> updateOrCreateUserInstitution(userDto, mailUuid, userInstitution, userResource.getId().toString()))
+                .onItem().invoke(userInstitution -> log.info("start persist userInstititon: {}", userInstitution))
+                .onItem().transformToUni(userInstitution -> userInstitutionService.persistOrUpdate(userInstitution))
+                .onItem().invoke(() -> log.info("UserInstitution persisted"))
+                .onFailure().invoke(exception -> log.error("Error during persist user on UserInstitution: {} ", exception.getMessage(), exception));
+    }
+
+    /**
+     * The createUserOnUserRegistryAndUserInstitution method is a method that creates a user on both the user registry and the user institution.
+     * The method starts by generates a new mailUuid and creates a workContacts map. It adds a new work contact to the map using the mailUuid
+     * as the key and the institution email from the userDto object as the value.
+     * Next, it attempts to save the user on the user registry using a PATCH request.
+     * After the user registry save operation, the method attempts to find the user institution by the user ID and institution ID from the userDto object.
+     * It then updates or creates the userinstitution model and it attempts to persist the user institution.
+     * If any of the operations fail, the method logs an error message and returns a Uni that emits a failure.
+     */
+    private Uni<Void> createUserOnUserRegistryAndUserInstitution(CreateUserDto userDto) {
+        log.info("Creating user on userRegistry and userInstitution");
+        String mailUuid = MAIL_ID_PREFIX + UUID.randomUUID();
+        Map<String, WorkContactResource> workContacts = new HashMap<>();
+        workContacts.put(mailUuid, UserUtils.buildWorkContact(userDto.getUser().getInstitutionEmail()));
+
+        return userRegistryApi.saveUsingPATCH(userMapper.toSaveUserDto(userDto.getUser(), workContacts))
+                .onFailure().invoke(exception -> log.error("Error during create user on userRegistry: {} ", exception.getMessage(), exception))
+                .onItem().invoke(userResource -> log.info("User created with id {}", userResource.getId()))
+                .onItem().transform(userId -> userId.getId().toString())
+                .onItem().transform(userId -> updateOrCreateUserInstitution(userDto, mailUuid, null, userId))
+                .onItem().invoke(userInstitution -> log.info("start persist userInstititon: {}", userInstitution))
+                .onItem().transformToUni(userInstitution -> userInstitutionService.persistOrUpdate(userInstitution))
+                .onItem().invoke(() -> log.info("UserInstitution persisted"))
+                .onFailure().invoke(exception -> log.error("Error during persist user on UserInstitution: {} ", exception.getMessage(), exception));
+    }
+
+    private UserInstitution updateOrCreateUserInstitution(CreateUserDto userDto, String mailUuid, UserInstitution userInstitution, String userId) {
+        if (userInstitution == null) {
+            log.info("UserInstitution with userId: {} and institutionId: {} not found", userId, userDto.getInstitutionId());
+            return userInstitutionMapper.toEntity(userDto, userId, mailUuid);
+        }
+
+        log.info("UserInstitution with userId: {} and institutionId: {} found", userId, userDto.getInstitutionId());
+        userInstitution.setUserMailUuid(mailUuid);
+        userInstitution.getProducts().add(onboardedProductMapper.toEntity(userDto.getProduct()));
+
+        return userInstitution;
     }
 }

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
@@ -15,9 +15,9 @@ import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import it.pagopa.selfcare.product.entity.Product;
 import it.pagopa.selfcare.product.service.ProductService;
 import it.pagopa.selfcare.user.constant.OnboardedProductState;
+import it.pagopa.selfcare.user.controller.request.CreateUserDto;
 import it.pagopa.selfcare.user.controller.response.UserInstitutionResponse;
 import it.pagopa.selfcare.user.controller.response.UserProductResponse;
-import it.pagopa.selfcare.user.controller.response.UserResponse;
 import it.pagopa.selfcare.user.entity.OnboardedProduct;
 import it.pagopa.selfcare.user.entity.UserInfo;
 import it.pagopa.selfcare.user.entity.UserInstitution;
@@ -28,6 +28,7 @@ import it.pagopa.selfcare.user.mapper.UserMapper;
 import it.pagopa.selfcare.user.model.LoggedUser;
 import it.pagopa.selfcare.user.model.notification.UserNotificationToSend;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
 import org.apache.http.HttpStatus;
 import org.bson.types.ObjectId;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -35,10 +36,7 @@ import org.jboss.resteasy.reactive.client.api.WebClientApplicationException;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.openapi.quarkus.user_registry_json.api.UserApi;
-import org.openapi.quarkus.user_registry_json.model.CertifiableFieldResourceOfLocalDate;
-import org.openapi.quarkus.user_registry_json.model.CertifiableFieldResourceOfstring;
-import org.openapi.quarkus.user_registry_json.model.UserResource;
-import org.openapi.quarkus.user_registry_json.model.WorkContactResource;
+import org.openapi.quarkus.user_registry_json.model.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -60,7 +58,7 @@ class UserServiceTest {
     @InjectMock
     private UserInstitutionService userInstitutionService;
     @InjectMock
-    private  UserNotificationService userNotificationService;
+    private UserNotificationService userNotificationService;
     @InjectMock
     private UserInfoService userInfoService;
 
@@ -90,7 +88,10 @@ class UserServiceTest {
         WorkContactResource workContactResource = new WorkContactResource();
         workContactResource.setEmail(certifiedEmail);
         userResource.setEmail(certifiedEmail);
-        userResource.setWorkContacts(Map.of("userMailUuid", workContactResource));
+
+        Map<String, WorkContactResource> map = new HashMap<>();
+        map.put("userMailUuid", workContactResource);
+        userResource.setWorkContacts(map);
 
         userInstitution = new UserInstitution();
         userInstitution.setId(ObjectId.get());
@@ -100,29 +101,32 @@ class UserServiceTest {
         userInstitution.setInstitutionRootName("institutionRootName");
         OnboardedProduct product = new OnboardedProduct();
         product.setProductId("test");
-        userInstitution.setProducts(List.of(product));
+        List<OnboardedProduct> products = new ArrayList<>();
+        products.add(product);
+        userInstitution.setProducts(products);
     }
 
     @Test
     void getUsersEmailsTest() {
 
-        when(userInstitutionService.findAllWithFilter(any())).thenReturn(Multi.createFrom().item(userInstitution));
-        when(userRegistryApi.findByIdUsingGET(any(), any()))
+        when(userInstitutionService.findAllWithFilter(anyMap())).thenReturn(Multi.createFrom().item(userInstitution));
+        when(userRegistryApi.findByIdUsingGET(anyString(), anyString()))
                 .thenReturn(Uni.createFrom().item(userResource));
 
         UniAssertSubscriber<List<String>> subscriber = userService
                 .getUsersEmails("institutionId", "productId")
                 .subscribe()
-                .withSubscriber(UniAssertSubscriber.create());
+                .withSubscriber(UniAssertSubscriber.create())
+                .assertCompleted();
 
-        List<String> actual = subscriber.assertCompleted().awaitItem().getItem();
+        List<String> actual = subscriber.assertCompleted().getItem();
         assertNotNull(actual);
         assertEquals(1, actual.size());
         assertEquals("test@test.it", actual.get(0));
     }
 
     @Test
-    void getUserById(){
+    void getUserById() {
         when(userRegistryApi.findByIdUsingGET(any(), any()))
                 .thenReturn(Uni.createFrom().item(userResource));
         UniAssertSubscriber<UserResource> subscriber = userService
@@ -177,7 +181,7 @@ class UserServiceTest {
         when(userInstitutionService.retrieveFirstFilteredUserInstitution(any())).thenReturn(Uni.createFrom().item(userInstitution));
         when(userRegistryApi.findByIdUsingGET(any(), any())).thenReturn(Uni.createFrom().item(userResource));
 
-        UniAssertSubscriber<UserResponse> subscriber = userService.retrievePerson("test-user", "test-product", "test-institutionId").subscribe().withSubscriber(UniAssertSubscriber.create());
+        UniAssertSubscriber<UserResource> subscriber = userService.retrievePerson("test-user", "test-product", "test-institutionId").subscribe().withSubscriber(UniAssertSubscriber.create());
         subscriber.assertCompleted();
     }
 
@@ -185,7 +189,7 @@ class UserServiceTest {
     void testRetrievePersonFailsWhenUserIsNotPresent() {
         when(userInstitutionService.retrieveFirstFilteredUserInstitution(any())).thenReturn(Uni.createFrom().nullItem());
 
-        UniAssertSubscriber<UserResponse> subscriber = userService
+        UniAssertSubscriber<UserResource> subscriber = userService
                 .retrievePerson("test-user", "test-product", "test-institutionId")
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
@@ -200,7 +204,7 @@ class UserServiceTest {
         when(userInstitutionService.retrieveFirstFilteredUserInstitution(any())).thenReturn(Uni.createFrom().item(userInstitution));
         when(userRegistryApi.findByIdUsingGET(any(), any())).thenReturn(Uni.createFrom().failure(new WebClientApplicationException(HttpStatus.SC_NOT_FOUND)));
 
-        UniAssertSubscriber<UserResponse> subscriber = userService.retrievePerson("test-user", "test-product", "test-institutionId").subscribe().withSubscriber(UniAssertSubscriber.create());
+        UniAssertSubscriber<UserResource> subscriber = userService.retrievePerson("test-user", "test-product", "test-institutionId").subscribe().withSubscriber(UniAssertSubscriber.create());
 
         subscriber.assertFailedWith(ResourceNotFoundException.class);
     }
@@ -352,7 +356,7 @@ class UserServiceTest {
     }
 
     @Test
-    void deleteUserInstitutionProductFound(){
+    void deleteUserInstitutionProductFound() {
         when(userInstitutionService.deleteUserInstitutionProduct("userId", "institutionId", "productId")).thenReturn(Uni.createFrom().item(1L));
         UniAssertSubscriber<Void> subscriber = userService
                 .deleteUserInstitutionProduct("userId", "institutionId", "productId")
@@ -364,7 +368,7 @@ class UserServiceTest {
     }
 
     @Test
-    void deleteUserInstitutionProductNotFound(){
+    void deleteUserInstitutionProductNotFound() {
         when(userInstitutionService.deleteUserInstitutionProduct("userId", "institutionId", "productId")).thenReturn(Uni.createFrom().item(0L));
         UniAssertSubscriber<Void> subscriber = userService
                 .deleteUserInstitutionProduct("userId", "institutionId", "productId")
@@ -456,7 +460,6 @@ class UserServiceTest {
         when(userRegistryApi.findByIdUsingGET(any(), any()))
                 .thenReturn(Uni.createFrom().item(userResource));
 
-
         UserInstitution userInstitutionResponse = mock(UserInstitution.class);
         when(userInstitutionService.retrieveFirstFilteredUserInstitution(anyMap()))
                 .thenReturn(Uni.createFrom().item(userInstitutionResponse));
@@ -502,4 +505,103 @@ class UserServiceTest {
                 any()
         );
     }
+
+    @Test
+    void testCreateOrUpdateUser_UpdateUser_Success() {
+        // Prepare test data
+        CreateUserDto createUserDto = new CreateUserDto();
+        CreateUserDto.User user = new CreateUserDto.User();
+        user.setFiscalCode("fiscalCode");
+        createUserDto.setUser(user);
+
+        // Mock external dependencies
+        when(userRegistryApi.searchUsingPOST(any(), any())).thenReturn(Uni.createFrom().item(userResource));
+        when(userInstitutionService.findByUserIdAndInstitutionId(any(), any())).thenReturn(Uni.createFrom().item(userInstitution));
+        when(userRegistryApi.updateUsingPATCH(any(), any())).thenReturn(Uni.createFrom().item(Response.ok().build()));
+        when(userInstitutionService.persistOrUpdate(any())).thenReturn(Uni.createFrom().voidItem());
+
+        // Call the method
+        UniAssertSubscriber<Void> subscriber = userService.createOrUpdateUser(createUserDto)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        // Verify the result
+        subscriber.assertCompleted();
+        verify(userRegistryApi).updateUsingPATCH(any(), any());
+        verify(userInstitutionService).persistOrUpdate(any());
+    }
+
+    @Test
+    void testCreateOrUpdateUser_CreateUser_Success() {
+        // Prepare test data
+        CreateUserDto createUserDto = new CreateUserDto();
+        CreateUserDto.User user = new CreateUserDto.User();
+        user.setFiscalCode("fiscalCode");
+        createUserDto.setUser(user);
+        CreateUserDto.Product product = new CreateUserDto.Product();
+        product.setProductId("productId");
+        createUserDto.setProduct(product);
+
+        // Mock external dependencies
+        when(userRegistryApi.searchUsingPOST(any(), any())).thenReturn(Uni.createFrom().failure(new WebClientApplicationException(HttpStatus.SC_NOT_FOUND)));
+        when(userRegistryApi.saveUsingPATCH(any())).thenReturn(Uni.createFrom().item(UserId.builder().id(UUID.randomUUID()).build()));
+        when(userInstitutionService.persistOrUpdate(any())).thenReturn(Uni.createFrom().voidItem());
+
+        // Call the method
+        UniAssertSubscriber<Void> subscriber = userService.createOrUpdateUser(createUserDto)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        // Verify the result
+        subscriber.assertCompleted();
+        verify(userRegistryApi).saveUsingPATCH(any());
+        verify(userInstitutionService).persistOrUpdate(any());
+    }
+
+    @Test
+    void testCreateOrUpdateUser_UpdateUser_UserRegistryUpdateFailed() {
+        // Prepare test data
+        CreateUserDto createUserDto = new CreateUserDto();
+        CreateUserDto.User user = new CreateUserDto.User();
+        user.setFiscalCode("fiscalCode");
+        createUserDto.setUser(user);
+
+        // Mock external dependencies
+        when(userRegistryApi.searchUsingPOST(any(), any())).thenReturn(Uni.createFrom().item(userResource));
+        when(userInstitutionService.findByUserIdAndInstitutionId(any(), any())).thenReturn(Uni.createFrom().item(userInstitution));
+        when(userRegistryApi.updateUsingPATCH(any(), any())).thenReturn(Uni.createFrom().failure(new RuntimeException()));
+        when(userInstitutionService.persistOrUpdate(any())).thenReturn(Uni.createFrom().voidItem());
+
+        // Call the method
+        UniAssertSubscriber<Void> subscriber = userService.createOrUpdateUser(createUserDto)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        // Verify the result
+        subscriber.assertFailedWith(RuntimeException.class);
+        verify(userRegistryApi).updateUsingPATCH(any(), any());
+        verify(userInstitutionService, never()).persistOrUpdate(any());
+    }
+
+    @Test
+    void testCreateOrUpdateUser_UpdateUser_UserInstitutionUpdateFailed() {
+        // Prepare test data
+        CreateUserDto createUserDto = new CreateUserDto();
+        CreateUserDto.User user = new CreateUserDto.User();
+        user.setFiscalCode("fiscalCode");
+        createUserDto.setUser(user);
+
+        // Mock external dependencies
+        when(userRegistryApi.searchUsingPOST(any(), any())).thenReturn(Uni.createFrom().item(userResource));
+        when(userInstitutionService.findByUserIdAndInstitutionId(any(), any())).thenReturn(Uni.createFrom().item(userInstitution));
+        when(userRegistryApi.updateUsingPATCH(any(), any())).thenReturn(Uni.createFrom().item(Response.ok().build()));
+        when(userInstitutionService.persistOrUpdate(any())).thenReturn(Uni.createFrom().failure(new RuntimeException()));
+
+        // Call the method
+        UniAssertSubscriber<Void> subscriber = userService.createOrUpdateUser(createUserDto)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        // Verify the result
+        subscriber.assertFailedWith(RuntimeException.class);
+        verify(userRegistryApi).updateUsingPATCH(any(), any());
+        verify(userInstitutionService).persistOrUpdate(any());
+    }
+
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Added API to create or update User on userRegistry and UserInstitution collection

#### Motivation and Context
 To adapt to the new data model and centralize all calls to PDV within the BE, it was necessary to add this new API. It will be invoked during onboarding completion and/or new user creation and will handle the persistence of the user on the userInstitution collection and the creation or update of the user on PDV.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.