### PR TITLE
[SELC-4365] Feat: Added Api to check user permission for APIs access

### DIFF
--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/constant/CustomError.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/constant/CustomError.java
@@ -1,11 +1,8 @@
 package it.pagopa.selfcare.user.constant;
 
 public enum CustomError {
-    ROLE_NOT_FOUND("0000", "ROLE_NOT_FOUND"),
-    ROLE_IS_NULL("0000", "ROLE_IS_NULL - Role is required if productRole is present"),
     USER_NOT_FOUND_ERROR("0031", "User having userId %s not found"),
-
-    PRODUCT_ROLE_NOT_FOUND("0000", "PRODUCT_ROLE_NOT_FOUND"),
+    USER_INSTITUTION_NOT_FOUND_ERROR("0031", "User having userId [%s] and institutionId [%s] not found"),
     STATUS_IS_MANDATORY("0000", "STATUS IS MANDATORY"),
     USER_TO_UPDATE_NOT_FOUND("0000", "USER TO UPDATE NOT FOUND"),
     USERS_TO_UPDATE_NOT_FOUND("0000", "USERS TO UPDATE NOT FOUND");

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/constant/PermissionTypeEnum.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/constant/PermissionTypeEnum.java
@@ -1,0 +1,6 @@
+package it.pagopa.selfcare.user.constant;
+
+public enum PermissionTypeEnum {
+    ADMIN,
+    ANY
+}

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/constant/SelfCareAuthority.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/constant/SelfCareAuthority.java
@@ -1,0 +1,6 @@
+package it.pagopa.selfcare.user.constant;
+
+public enum SelfCareAuthority {
+    ADMIN,
+    LIMITED
+}

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/constant/SelfCareRole.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/constant/SelfCareRole.java
@@ -1,0 +1,18 @@
+package it.pagopa.selfcare.user.constant;
+
+public enum SelfCareRole {
+    MANAGER(SelfCareAuthority.ADMIN),
+    DELEGATE(SelfCareAuthority.ADMIN),
+    SUB_DELEGATE(SelfCareAuthority.ADMIN),
+    OPERATOR(SelfCareAuthority.LIMITED);
+
+    private SelfCareAuthority selfCareAuthority;
+
+    private SelfCareRole(SelfCareAuthority selfCareAuthority) {
+        this.selfCareAuthority = selfCareAuthority;
+    }
+
+    public SelfCareAuthority getSelfCareAuthority() {
+        return this.selfCareAuthority;
+    }
+}

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/UserPermissionController.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/UserPermissionController.java
@@ -1,0 +1,50 @@
+package it.pagopa.selfcare.user.controller;
+
+import io.quarkus.security.Authenticated;
+import io.smallrye.mutiny.Uni;
+import it.pagopa.selfcare.user.constant.PermissionTypeEnum;
+import it.pagopa.selfcare.user.service.UserPermissionService;
+import it.pagopa.selfcare.user.util.UserUtils;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.SecurityContext;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+
+@Path("/authorize")
+@Slf4j
+@Authenticated
+@AllArgsConstructor
+public class UserPermissionController {
+    private final UserPermissionService userPermissionService;
+    private final UserUtils userUtils;
+
+    /**
+     * Retrieves the permission for a user in an institution.
+     *
+     * @param institutionId The ID of the institution.
+     * @param productId     The ID of the product (optional).
+     * @param permission    The permission to check.
+     * @param ctx           The security context.
+     * @return A Uni<Boolean> indicating whether the user has the specified
+     *         permission.
+     */
+    @Operation(summary = "Get permission for a user in an institution")
+    @GET
+    @Path("/{institutionId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Uni<Boolean> getPermission(
+            @NotEmpty(message = "institutionId is required") @PathParam("institutionId") String institutionId,
+            @QueryParam("productId") String productId,
+            @NotNull(message = "Permission type is required") @QueryParam("permission") PermissionTypeEnum permission,
+            @Context SecurityContext ctx) {
+
+        return userUtils.readUserIdFromToken(ctx)
+                .onItem().transformToUni(loggedUser -> userPermissionService.hasPermission(institutionId, productId, permission, loggedUser.getUid()))
+                .onItem().invoke(result -> log.info("User has permission: {}", result));
+    }
+}

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserPermissionService.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserPermissionService.java
@@ -1,0 +1,8 @@
+package it.pagopa.selfcare.user.service;
+
+import io.smallrye.mutiny.Uni;
+import it.pagopa.selfcare.user.constant.PermissionTypeEnum;
+
+public interface UserPermissionService {
+     Uni<Boolean>hasPermission(String institutionId, String productId, PermissionTypeEnum permission, String userId);
+}

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserPermissionServiceImpl.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserPermissionServiceImpl.java
@@ -1,0 +1,55 @@
+package it.pagopa.selfcare.user.service;
+
+import io.smallrye.mutiny.Uni;
+import it.pagopa.selfcare.user.constant.PermissionTypeEnum;
+import it.pagopa.selfcare.user.constant.SelfCareRole;
+import it.pagopa.selfcare.user.entity.UserInstitution;
+import it.pagopa.selfcare.user.entity.filter.OnboardedProductFilter;
+import it.pagopa.selfcare.user.entity.filter.UserInstitutionFilter;
+import it.pagopa.selfcare.user.exception.ResourceNotFoundException;
+import it.pagopa.selfcare.user.util.UserUtils;
+import jakarta.enterprise.context.ApplicationScoped;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Map;
+
+import static it.pagopa.selfcare.user.constant.CustomError.USER_INSTITUTION_NOT_FOUND_ERROR;
+import static it.pagopa.selfcare.user.constant.CustomError.USER_NOT_FOUND_ERROR;
+
+@Slf4j
+@ApplicationScoped
+@RequiredArgsConstructor
+public class UserPermissionServiceImpl implements UserPermissionService {
+
+    private final UserInstitutionService userInstitutionService;
+    private final UserUtils userUtils;
+
+    @Override
+    public Uni<Boolean> hasPermission(String institutionId, String productId, PermissionTypeEnum permission, String userId) {
+        log.trace("hasPermission start");
+        log.debug("hasPermission institutionId = {}, productId = {}, permission = {}", institutionId, productId, permission);
+
+        return retrievePerson(userId, productId, institutionId)
+                .onItem().transform(userInstitution -> PermissionTypeEnum.ANY.equals(permission) || checkProductRole(userInstitution, productId, permission))
+                .onFailure(ResourceNotFoundException.class).recoverWithItem(false);
+    }
+
+    private boolean checkProductRole(UserInstitution userInstitution, String productId, PermissionTypeEnum permission) {
+        return userInstitution.getProducts().stream()
+                .anyMatch(product -> permission.name().equalsIgnoreCase(SelfCareRole.valueOf(product.getRole().name()).getSelfCareAuthority().name()) &&
+                        (StringUtils.isBlank(productId) || product.getProductId().equalsIgnoreCase(productId)));
+    }
+
+    private Uni<UserInstitution> retrievePerson(String userId, String productId, String institutionId) {
+        var userInstitutionFilters = UserInstitutionFilter.builder().userId(userId).institutionId(institutionId).build().constructMap();
+        var productFilters = OnboardedProductFilter.builder().productId(productId).build().constructMap();
+        Map<String, Object> queryParameter = userUtils.retrieveMapForFilter(userInstitutionFilters, productFilters);
+        return userInstitutionService.retrieveFirstFilteredUserInstitution(queryParameter)
+                .onItem().ifNull().failWith(() -> {
+                    log.error(String.format(USER_INSTITUTION_NOT_FOUND_ERROR.getMessage(), userId, institutionId));
+                    return new ResourceNotFoundException(String.format(USER_INSTITUTION_NOT_FOUND_ERROR.getMessage(), userId, institutionId), USER_NOT_FOUND_ERROR.getCode());
+                });
+    }
+}

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/controller/UserPermissionControllerTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/controller/UserPermissionControllerTest.java
@@ -1,0 +1,85 @@
+package it.pagopa.selfcare.user.controller;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import io.smallrye.mutiny.Uni;
+import it.pagopa.selfcare.user.constant.PermissionTypeEnum;
+import it.pagopa.selfcare.user.model.LoggedUser;
+import it.pagopa.selfcare.user.service.UserPermissionService;
+import it.pagopa.selfcare.user.util.UserUtils;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static it.pagopa.selfcare.user.constant.PermissionTypeEnum.ADMIN;
+import static org.mockito.Mockito.*;
+
+@QuarkusTest
+@TestHTTPEndpoint(UserPermissionController.class)
+class UserPermissionControllerTest {
+    @InjectMock
+    UserPermissionService userPermissionService;
+
+    @InjectMock
+    UserUtils userUtils;
+
+    private final String institutionIdField = "institutionId";
+    private final String productIdField = "productId";
+    private final String institutionId = UUID.randomUUID().toString();
+    private final  String productId = "prod-io";
+    private final String userId = UUID.randomUUID().toString();
+
+    @Test
+    void testGetPermissionUnhauthorize() {
+        // Mock input parameters
+
+        // Perform the API call without providing the permission query parameter
+        given()
+                .pathParam(institutionIdField, institutionId)
+                .queryParam(productIdField, productId)
+                .when()
+                .get("/{institutionId}")
+                .then()
+                .statusCode(401);
+
+        // Verify that the methods were not called
+        verifyNoInteractions(userPermissionService);
+    }
+
+    @Test
+    @TestSecurity(user = "userJwt")
+    void testGetPermission() {
+        // Mock input parameters
+        PermissionTypeEnum permission = ADMIN;
+
+        SecurityContext securityContext = mock(SecurityContext.class);
+        when(securityContext.getUserPrincipal()).thenReturn(() -> "userJwt");
+
+        // Mock userUtils.readUserIdFromToken() method
+        when(userUtils.readUserIdFromToken(any())).thenReturn(Uni.createFrom().item(LoggedUser.builder().uid(userId).build()));
+
+        // Mock userPermissionService.hasPermission() method
+        when(userPermissionService.hasPermission(institutionId, productId, permission,userId)).thenReturn(Uni.createFrom().item(Boolean.TRUE));
+
+        // Perform the API call
+        given()
+                .pathParam(institutionIdField, institutionId)
+                .queryParam(productIdField, productId)
+                .queryParam("permission", permission)
+                .when()
+                .get("/{institutionId}")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType(MediaType.APPLICATION_JSON);
+
+        // Verify that the methods were called with the expected parameters
+        verify(userPermissionService).hasPermission(institutionId, productId, permission, userId);
+    }
+}

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserPermissionServiceImplTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserPermissionServiceImplTest.java
@@ -1,0 +1,98 @@
+package it.pagopa.selfcare.user.service;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.mutiny.Uni;
+import it.pagopa.selfcare.onboarding.common.PartyRole;
+import it.pagopa.selfcare.user.constant.PermissionTypeEnum;
+import it.pagopa.selfcare.user.entity.OnboardedProduct;
+import it.pagopa.selfcare.user.entity.UserInstitution;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+
+@QuarkusTest
+public class UserPermissionServiceImplTest {
+
+    @InjectMock
+    UserInstitutionService userInstitutionService;
+
+    @Inject
+    UserPermissionService userPermissionService;
+
+    private final String institutionId = UUID.randomUUID().toString();
+    private final String productId = "prod-io";
+    private final String userId = "userId";
+
+
+    @Test
+    public void testHasPermissionWithAnyPermission() {
+        // Arrange
+        UserInstitution userInstitution = new UserInstitution();
+        userInstitution.setProducts(Collections.emptyList());
+        Mockito.when(userInstitutionService.retrieveFirstFilteredUserInstitution(anyMap())).thenReturn(Uni.createFrom().item(userInstitution));
+
+        // Act
+        Uni<Boolean> result = userPermissionService.hasPermission(institutionId, productId, PermissionTypeEnum.ANY, userId);
+        UniAssertSubscriber<Boolean> subscriber = result.subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        // Assert
+        subscriber.assertCompleted().assertItem(true);
+    }
+
+    @Test
+    public void testHasPermissionWithValidPermission() {
+        // Arrange
+        UserInstitution userInstitution = new UserInstitution();
+        OnboardedProduct product = new OnboardedProduct();
+        product.setRole(PartyRole.MANAGER);
+        product.setProductId(productId);
+        userInstitution.setProducts(Collections.singletonList(product));
+        Mockito.when(userInstitutionService.retrieveFirstFilteredUserInstitution(anyMap())).thenReturn(Uni.createFrom().item(userInstitution));
+
+        // Act
+        Uni<Boolean> result = userPermissionService.hasPermission(institutionId, productId, PermissionTypeEnum.ADMIN, userId);
+        UniAssertSubscriber<Boolean> subscriber = result.subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        // Assert
+        subscriber.assertCompleted().assertItem(true);
+    }
+
+    @Test
+    public void testHasPermissionWithInvalidPermission() {
+        // Arrange
+        UserInstitution userInstitution = new UserInstitution();
+        OnboardedProduct product = new OnboardedProduct();
+        product.setRole(PartyRole.OPERATOR);
+        product.setProductId(productId);
+        userInstitution.setProducts(Collections.singletonList(product));
+        Mockito.when(userInstitutionService.retrieveFirstFilteredUserInstitution(anyMap())).thenReturn(Uni.createFrom().item(userInstitution));
+
+        // Act
+        Uni<Boolean> result = userPermissionService.hasPermission(institutionId, productId, PermissionTypeEnum.ADMIN, userId);
+        UniAssertSubscriber<Boolean> subscriber = result.subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        // Assert
+        subscriber.assertCompleted().assertItem(false);
+    }
+
+    @Test
+    public void testHasPermissionWithUserNotFound() {
+        // Arrange
+        Mockito.when(userInstitutionService.retrieveFirstFilteredUserInstitution(anyMap())).thenReturn(Uni.createFrom().nullItem());
+
+        // Act
+        Uni<Boolean> result = userPermissionService.hasPermission(institutionId, productId, PermissionTypeEnum.ANY, userId);
+        UniAssertSubscriber<Boolean> assertSubscriber = result.subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        // Assert
+        assertSubscriber.assertCompleted().assertItem(false);
+    }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Added Api to check user permission for APIs access

#### Motivation and Context
In order to move all user permission checks for API access, it is necessary to create a new API on selfcare user that verifies whether the user has the permissions or not, and returns a boolean that corresponds to allowed (true) or deny (false) to the caller.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.