### PR TITLE
[SELC-4683] fix: added filters to remove products from userinstitution records

### DIFF
--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
@@ -887,9 +887,13 @@ class UserServiceTest {
         OnboardedProduct prodIo = new OnboardedProduct();
         prodIo.setProductId("prod-io");
         prodIo.setStatus(OnboardedProductState.ACTIVE);
+        prodIo.setRole(MANAGER);
+        prodIo.setProductRole("test-productRole");
         OnboardedProduct prodPagoPa = new OnboardedProduct();
         prodPagoPa.setProductId("prod-pagopa");
         prodPagoPa.setStatus(OnboardedProductState.ACTIVE);
+        prodPagoPa.setRole(MANAGER);
+        prodPagoPa.setProductRole("test-productRole");
         userInstitution.setUserId(userUuid);
         userInstitution.setInstitutionId(institutionId);
         List<OnboardedProduct> productsList = new ArrayList<>();

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
@@ -872,14 +872,14 @@ class UserServiceTest {
     }
 
     @Test
-    void testRetrieveUsersDataRemovingProductsWhenFiltersAreNotMet() {
+    void testRetrieveUsersDataRemovingProductsWhenProductFilterIsPresent() {
         // Prepare test data
         String institutionId = "test-institution";
         String personId = "test-person";
-        List<String> roles = Collections.singletonList("test-role");
-        List<String> states = Collections.singletonList(OnboardedProductState.ACTIVE.name());
+        List<String> roles = Collections.emptyList();
+        List<String> states = Collections.emptyList();
         List<String> products = Collections.singletonList("prod-io");
-        List<String> productRoles = Collections.singletonList("test-productRole");
+        List<String> productRoles = Collections.emptyList();
         String userUuid = "test-userUuid";
 
         UserInstitution userInstitution = new UserInstitution();
@@ -894,6 +894,118 @@ class UserServiceTest {
         prodPagoPa.setStatus(OnboardedProductState.ACTIVE);
         prodPagoPa.setRole(MANAGER);
         prodPagoPa.setProductRole("test-productRole");
+        userInstitution.setUserId(userUuid);
+        userInstitution.setInstitutionId(institutionId);
+        List<OnboardedProduct> productsList = new ArrayList<>();
+        productsList.add(prodIo);
+        productsList.add(prodPagoPa);
+        userInstitution.setProducts(productsList);
+
+        UserResource userResource = new UserResource();
+        userResource.setId(UUID.randomUUID());
+
+        // Mock external dependencies
+        when(userInstitutionService.retrieveFirstFilteredUserInstitution(anyMap())).thenReturn(Uni.createFrom().item(userInstitution));
+        when(userInstitutionService.findAllWithFilter(anyMap())).thenReturn(Multi.createFrom().item(userInstitution));
+        when(userRegistryApi.findByIdUsingGET(any(), any())).thenReturn(Uni.createFrom().item(userResource));
+
+        // Call the method
+        AssertSubscriber<UserDataResponse> subscriber = userService.retrieveUsersData(institutionId, personId, roles, states, products, productRoles, userUuid)
+                .subscribe().withSubscriber(AssertSubscriber.create());
+
+        // Verify the result
+        subscriber.assertCompleted().getItems().forEach(actual -> {
+            assertNotNull(actual);
+            assertEquals(1, actual.getProducts().size());
+            assertEquals("prod-io", actual.getProducts().get(0).getProductId());
+            assertEquals(institutionId, "test-institution");
+        });
+
+        // Verify the interactions
+        verify(userInstitutionService).retrieveFirstFilteredUserInstitution(anyMap());
+        verify(userInstitutionService).findAllWithFilter(any());
+        verify(userRegistryApi).findByIdUsingGET(any(), any());
+    }
+
+    @Test
+    void testRetrieveUsersDataRemovingProductsWhenStatesFilterIsPresent() {
+        // Prepare test data
+        String institutionId = "test-institution";
+        String personId = "test-person";
+        List<String> roles = Collections.emptyList();
+        List<String> states = Collections.singletonList("ACTIVE");
+        List<String> products = Collections.emptyList();
+        List<String> productRoles = Collections.emptyList();
+        String userUuid = "test-userUuid";
+
+        UserInstitution userInstitution = new UserInstitution();
+
+        OnboardedProduct prodIo = new OnboardedProduct();
+        prodIo.setProductId("prod-io");
+        prodIo.setStatus(OnboardedProductState.ACTIVE);
+        prodIo.setRole(MANAGER);
+        prodIo.setProductRole("test-productRole");
+        OnboardedProduct prodPagoPa = new OnboardedProduct();
+        prodPagoPa.setProductId("prod-pagopa");
+        prodPagoPa.setStatus(OnboardedProductState.PENDING);
+        prodPagoPa.setRole(MANAGER);
+        prodPagoPa.setProductRole("test-productRole");
+        userInstitution.setUserId(userUuid);
+        userInstitution.setInstitutionId(institutionId);
+        List<OnboardedProduct> productsList = new ArrayList<>();
+        productsList.add(prodIo);
+        productsList.add(prodPagoPa);
+        userInstitution.setProducts(productsList);
+
+        UserResource userResource = new UserResource();
+        userResource.setId(UUID.randomUUID());
+
+        // Mock external dependencies
+        when(userInstitutionService.retrieveFirstFilteredUserInstitution(anyMap())).thenReturn(Uni.createFrom().item(userInstitution));
+        when(userInstitutionService.findAllWithFilter(anyMap())).thenReturn(Multi.createFrom().item(userInstitution));
+        when(userRegistryApi.findByIdUsingGET(any(), any())).thenReturn(Uni.createFrom().item(userResource));
+
+        // Call the method
+        AssertSubscriber<UserDataResponse> subscriber = userService.retrieveUsersData(institutionId, personId, roles, states, products, productRoles, userUuid)
+                .subscribe().withSubscriber(AssertSubscriber.create());
+
+        // Verify the result
+        subscriber.assertCompleted().getItems().forEach(actual -> {
+            assertNotNull(actual);
+            assertEquals(1, actual.getProducts().size());
+            assertEquals("prod-io", actual.getProducts().get(0).getProductId());
+            assertEquals(institutionId, "test-institution");
+        });
+
+        // Verify the interactions
+        verify(userInstitutionService).retrieveFirstFilteredUserInstitution(anyMap());
+        verify(userInstitutionService).findAllWithFilter(any());
+        verify(userRegistryApi).findByIdUsingGET(any(), any());
+    }
+
+    @Test
+    void testRetrieveUsersDataRemovingProductsWhenProductRolesFilterIsPresent() {
+        // Prepare test data
+        String institutionId = "test-institution";
+        String personId = "test-person";
+        List<String> roles = Collections.emptyList();
+        List<String> states = Collections.emptyList();
+        List<String> products = Collections.emptyList();
+        List<String> productRoles = Collections.singletonList("test-productRole");
+        String userUuid = "test-userUuid";
+
+        UserInstitution userInstitution = new UserInstitution();
+
+        OnboardedProduct prodIo = new OnboardedProduct();
+        prodIo.setProductId("prod-io");
+        prodIo.setStatus(OnboardedProductState.ACTIVE);
+        prodIo.setRole(MANAGER);
+        prodIo.setProductRole("test-productRole");
+        OnboardedProduct prodPagoPa = new OnboardedProduct();
+        prodPagoPa.setProductId("prod-pagopa");
+        prodPagoPa.setStatus(OnboardedProductState.ACTIVE);
+        prodPagoPa.setRole(MANAGER);
+        prodPagoPa.setProductRole("test-productRole2");
         userInstitution.setUserId(userUuid);
         userInstitution.setInstitutionId(institutionId);
         List<OnboardedProduct> productsList = new ArrayList<>();

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
@@ -872,6 +872,58 @@ class UserServiceTest {
     }
 
     @Test
+    void testRetrieveUsersDataRemovingProductsWhenFiltersAreNotMet() {
+        // Prepare test data
+        String institutionId = "test-institution";
+        String personId = "test-person";
+        List<String> roles = Collections.singletonList("test-role");
+        List<String> states = Collections.singletonList(OnboardedProductState.ACTIVE.name());
+        List<String> products = Collections.singletonList("prod-io");
+        List<String> productRoles = Collections.singletonList("test-productRole");
+        String userUuid = "test-userUuid";
+
+        UserInstitution userInstitution = new UserInstitution();
+
+        OnboardedProduct prodIo = new OnboardedProduct();
+        prodIo.setProductId("prod-io");
+        prodIo.setStatus(OnboardedProductState.ACTIVE);
+        OnboardedProduct prodPagoPa = new OnboardedProduct();
+        prodPagoPa.setProductId("prod-pagopa");
+        prodPagoPa.setStatus(OnboardedProductState.ACTIVE);
+        userInstitution.setUserId(userUuid);
+        userInstitution.setInstitutionId(institutionId);
+        List<OnboardedProduct> productsList = new ArrayList<>();
+        productsList.add(prodIo);
+        productsList.add(prodPagoPa);
+        userInstitution.setProducts(productsList);
+
+        UserResource userResource = new UserResource();
+        userResource.setId(UUID.randomUUID());
+
+        // Mock external dependencies
+        when(userInstitutionService.retrieveFirstFilteredUserInstitution(anyMap())).thenReturn(Uni.createFrom().item(userInstitution));
+        when(userInstitutionService.findAllWithFilter(anyMap())).thenReturn(Multi.createFrom().item(userInstitution));
+        when(userRegistryApi.findByIdUsingGET(any(), any())).thenReturn(Uni.createFrom().item(userResource));
+
+        // Call the method
+        AssertSubscriber<UserDataResponse> subscriber = userService.retrieveUsersData(institutionId, personId, roles, states, products, productRoles, userUuid)
+                .subscribe().withSubscriber(AssertSubscriber.create());
+
+        // Verify the result
+        subscriber.assertCompleted().getItems().forEach(actual -> {
+            assertNotNull(actual);
+            assertEquals(1, actual.getProducts().size());
+            assertEquals("prod-io", actual.getProducts().get(0).getProductId());
+            assertEquals(institutionId, "test-institution");
+        });
+
+        // Verify the interactions
+        verify(userInstitutionService).retrieveFirstFilteredUserInstitution(anyMap());
+        verify(userInstitutionService).findAllWithFilter(any());
+        verify(userRegistryApi).findByIdUsingGET(any(), any());
+    }
+
+    @Test
     void testRetrieveUsersDataWithNoAdminRole() {
         // Prepare test data
         String institutionId = "test-institution";


### PR DESCRIPTION
#### List of Changes

Added products, status, roles, productRoles filters to remove products from userinstitution records retrieved

#### Motivation and Context

The fix is mandatory it allows to filter on products, status, roles, productRoles of products after the query results are retrieved, because currently the API only performs a filter on the query, but because of the structure of the UserInstitution collection if a user has multiple products both those who pass the filters and those who don't pass the filters are returned.

#### How Has This Been Tested?

local env

#### Screenshots (if appropriate):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.