### PR TITLE
feat: restart cdc after resume token at startup

### DIFF
--- a/apps/user-cdc/src/main/java/it/pagopa/selfcare/user/event/CdcLifecycle.java
+++ b/apps/user-cdc/src/main/java/it/pagopa/selfcare/user/event/CdcLifecycle.java
@@ -36,21 +36,4 @@ public class CdcLifecycle {
                 .buildClient();
         tableServiceClient.createTableIfNotExists(tableName);
     }
-
-    void onStop(@Observes ShutdownEvent ev) {
-        log.info("The application is stopping...");
-
-        // Table CdCStartAt will be updated with the time of shutdown
-        Map<String, Object> properties = new HashMap<>();
-        properties.put(CDC_START_AT_PROPERTY, LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
-
-        TableEntity newEmployee = new TableEntity(CDC_START_AT_PARTITION_KEY, CDC_START_AT_ROW_KEY)
-                .setProperties(properties);
-
-        TableClient tableClient = new TableClientBuilder()
-                .connectionString(storageConnectionString)
-                .tableName(tableName)
-                .buildClient();
-        tableClient.upsertEntity(newEmployee);
-    }
 }

--- a/apps/user-cdc/src/main/java/it/pagopa/selfcare/user/event/UserInstitutionCdcService.java
+++ b/apps/user-cdc/src/main/java/it/pagopa/selfcare/user/event/UserInstitutionCdcService.java
@@ -138,6 +138,17 @@ public class UserInstitutionCdcService {
                         });
     }
 
+    private void updateLastResumeToken(BsonDocument resumeToken) {
+        // Table CdCStartAt will be updated with the last resume token
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(CDC_START_AT_PROPERTY, resumeToken.toJson());
+
+        TableEntity tableEntity = new TableEntity(CDC_START_AT_PARTITION_KEY, CDC_START_AT_ROW_KEY)
+                .setProperties(properties);
+        tableClient.upsertEntity(tableEntity);
+
+    }
+
     private void constructMapAndTrackEvent(String documentKey, String success, String... metrics) {
         Map<String, String> propertiesMap = new HashMap<>();
         propertiesMap.put("documentKey", documentKey);

--- a/apps/user-cdc/src/main/java/it/pagopa/selfcare/user/event/UserInstitutionCdcService.java
+++ b/apps/user-cdc/src/main/java/it/pagopa/selfcare/user/event/UserInstitutionCdcService.java
@@ -18,6 +18,7 @@ import it.pagopa.selfcare.user.event.entity.UserInstitution;
 import it.pagopa.selfcare.user.event.repository.UserInstitutionRepository;
 import jakarta.enterprise.context.ApplicationScoped;
 import lombok.extern.slf4j.Slf4j;
+import org.bson.BsonDocument;
 import org.bson.BsonTimestamp;
 import org.bson.conversions.Bson;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -25,10 +26,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.mongodb.client.model.Projections.fields;
 import static com.mongodb.client.model.Projections.include;
@@ -81,20 +79,22 @@ public class UserInstitutionCdcService {
     private void initOrderStream() {
         log.info("Starting initOrderStream ... ");
 
-        //Handling startAtOperationTime for watching collection at specific time
-        long startAtLong = LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        //Retrieve last resumeToken for watching collection at specific operation
+        String resumeToken = null;
         try {
             TableEntity cdcStartAtEntity = tableClient.getEntity(CDC_START_AT_PARTITION_KEY, CDC_START_AT_ROW_KEY);
-            if(cdcStartAtEntity == null)
-                startAtLong = (Long) cdcStartAtEntity.getProperty(CDC_START_AT_PROPERTY);
+            if(Objects.nonNull(cdcStartAtEntity))
+                resumeToken = (String) cdcStartAtEntity.getProperty(CDC_START_AT_PROPERTY);
         } catch (TableServiceException e) {
             log.error("Table StarAt not found, it is starting from now ...");
         }
 
+        // Initialize watching collection
         ReactiveMongoCollection<UserInstitution> dataCollection = getCollection();
         ChangeStreamOptions options = new ChangeStreamOptions()
-                .fullDocument(FullDocument.UPDATE_LOOKUP)
-                .startAtOperationTime(new BsonTimestamp(startAtLong));
+                .fullDocument(FullDocument.UPDATE_LOOKUP);
+        if(Objects.nonNull(resumeToken))
+            options = options.resumeAfter(BsonDocument.parse(resumeToken));
 
         Bson match = Aggregates.match(Filters.in("operationType", asList("update", "replace", "insert")));
         Bson project = Aggregates.project(fields(include("_id", "ns", "documentKey", "fullDocument")));
@@ -130,6 +130,7 @@ public class UserInstitutionCdcService {
                 .subscribe().with(
                         result -> {
                             log.info("UserInfo collection successfully updated from UserInstitution document having id: {}", document.getDocumentKey().toJson());
+                            updateLastResumeToken(document.getResumeToken());
                             constructMapAndTrackEvent(document.getDocumentKey().toJson(), "TRUE", USERINSTITUTION_SUCCESS_MECTRICS);
                         },
                         failure -> {
@@ -156,7 +157,6 @@ public class UserInstitutionCdcService {
 
         Map<String, Double> metricsMap = new HashMap<>();
         Arrays.stream(metrics).forEach(metricName -> metricsMap.put(metricName, 1D));
-
         telemetryClient.trackEvent(EVENT_NAME, propertiesMap, metricsMap);
     }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* Remove resume at startOperationTime
* Added resume after last token
* Saving last token on azure table

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
attempt resuming notifications starting after the operation specified in the resume token.

Each change stream event document includes a resume token as the _id field. Pass the entire _id field of the change event document that represents the operation you want to resume after.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.