### PR TITLE
fix constructTemplate for mail when institutionDescription is null

### DIFF
--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserNotificationServiceImpl.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserNotificationServiceImpl.java
@@ -97,8 +97,8 @@ public class UserNotificationServiceImpl implements UserNotificationService {
         dataModel.put("requesterName", loggedUser.getName());
         dataModel.put("requesterSurname", loggedUser.getFamilyName());
 
-        dataModel.put("productName", product.getTitle());
-        dataModel.put("institutionName", institutionDescription);
+        dataModel.put("productName", Optional.ofNullable(product.getTitle()).orElse(""));
+        dataModel.put("institutionName", Optional.ofNullable(institutionDescription).orElse(""));
         if (roleLabels.size() > 1) {
             String roleLabel = roleLabels.stream()
                     .limit(roleLabels.size() - 1L)
@@ -125,9 +125,9 @@ public class UserNotificationServiceImpl implements UserNotificationService {
         }
 
         Map<String, String> dataModel = new HashMap<>();
-        dataModel.put("productName", product.getTitle());
+        dataModel.put("productName", Optional.ofNullable(product.getTitle()).orElse(""));
         dataModel.put("productRole", roleLabel.orElse("no_role_found"));
-        dataModel.put("institutionName", institution.getInstitutionDescription());
+        dataModel.put("institutionName", Optional.ofNullable(institution.getInstitutionDescription()).orElse(""));
         dataModel.put("requesterName", loggedUserName);
         dataModel.put("requesterSurname", loggedUserSurname);
         return dataModel;

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserNotificationServiceImplTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserNotificationServiceImplTest.java
@@ -160,6 +160,67 @@ class UserNotificationServiceImplTest {
     }
 
     @Test
+    void testSendMailNotificationWithNullInstitutionDescription() throws IOException {
+        String loggedUserName = "loggedUserName";
+        String loggedUserSurname = "loggedUserSurname";
+
+        Configuration freemarkerConfig = mock(Configuration.class);
+        CloudTemplateLoader cloudTemplateLoader = mock(CloudTemplateLoader.class);
+        when(freemarkerConfig.getTemplate(anyString())).thenReturn(mock(freemarker.template.Template.class));
+        when(freemarkerConfig.getTemplateLoader()).thenReturn(cloudTemplateLoader);
+
+        UserNotificationServiceImpl userNotificationServiceImpl = new UserNotificationServiceImpl(freemarkerConfig, cloudTemplateLoader, mailService, true);
+        when(mailService.sendMail(anyString(), anyString(), anyString())).thenReturn(Uni.createFrom().voidItem());
+
+        userNotificationServiceImpl.sendEmailNotification(
+                        userResource,
+                        userInstitution,
+                        product,
+                        OnboardedProductState.ACTIVE,
+                        loggedUserName,
+                        loggedUserSurname
+                )
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create())
+                .awaitItem().assertCompleted();
+        userNotificationServiceImpl.sendEmailNotification(
+                        userResource,
+                        userInstitution,
+                        product,
+                        OnboardedProductState.DELETED,
+                        loggedUserName,
+                        loggedUserSurname
+                )
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create())
+                .awaitItem().assertCompleted();
+        userNotificationServiceImpl.sendEmailNotification(
+                        userResource,
+                        userInstitution,
+                        product,
+                        OnboardedProductState.SUSPENDED,
+                        loggedUserName,
+                        loggedUserSurname
+                )
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create())
+                .awaitItem().assertCompleted();
+        userNotificationServiceImpl.sendEmailNotification(
+                        userResource,
+                        userInstitution,
+                        product,
+                        OnboardedProductState.PENDING,
+                        loggedUserName,
+                        loggedUserSurname
+                )
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create())
+                .awaitItem().assertCompleted();
+        verify(mailService, times(3)).sendMail(anyString(), anyString(), anyString());
+    }
+
+
+    @Test
     void testSendKafkaNotification(){
         UserNotificationToSend userNotificationToSend = new UserNotificationToSend();
         userNotificationToSend.setId("userId");
@@ -194,6 +255,38 @@ class UserNotificationServiceImplTest {
         List<String> roleLabels = List.of("label");
         userNotificationServiceImpl.sendCreateUserNotification(
                         userInstitution.getInstitutionDescription(),
+                        roleLabels,
+                        userResource,
+                        userInstitution,
+                        product,
+                        loggedUser
+                )
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create())
+                .awaitItem().assertCompleted();
+        verify(mailService, times(1)).sendMail(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void testSendCreateUserNotificationWithNullInstitutionDescription() throws IOException {
+        String loggedUserName = "loggedUserName";
+        String loggedUserSurname = "loggedUserSurname";
+        LoggedUser loggedUser = LoggedUser.builder()
+                .name(loggedUserName)
+                .familyName(loggedUserSurname)
+                .build();
+
+        Configuration freemarkerConfig = mock(Configuration.class);
+        CloudTemplateLoader cloudTemplateLoader = mock(CloudTemplateLoader.class);
+        when(freemarkerConfig.getTemplate(anyString())).thenReturn(mock(freemarker.template.Template.class));
+        when(freemarkerConfig.getTemplateLoader()).thenReturn(cloudTemplateLoader);
+
+        UserNotificationServiceImpl userNotificationServiceImpl = new UserNotificationServiceImpl(freemarkerConfig, cloudTemplateLoader, mailService, true);
+
+        when(mailService.sendMail(anyString(), anyString(), anyString())).thenReturn(Uni.createFrom().voidItem());
+        List<String> roleLabels = List.of("label");
+        userNotificationServiceImpl.sendCreateUserNotification(
+                        null,
                         roleLabels,
                         userResource,
                         userInstitution,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Fixed constructTemplate for mail when institutionDescription is null
<!--- Describe your changes in detail -->

#### Motivation and Context
During the creation of the email for the user, we might have the institution description equal to null. This field in the data model should not be null but an empty string.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.