### PR TITLE
[SELC-4772] fix: Update workContract on userRegistry using an empty map

### DIFF
--- a/apps/user-cdc/src/main/java/it/pagopa/selfcare/user/event/CdcLifecycle.java
+++ b/apps/user-cdc/src/main/java/it/pagopa/selfcare/user/event/CdcLifecycle.java
@@ -7,6 +7,7 @@ import com.azure.data.tables.TableServiceClientBuilder;
 import com.azure.data.tables.models.TableEntity;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
+import io.quarkus.runtime.configuration.ConfigUtils;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static it.pagopa.selfcare.user.event.constant.CdcStartAtConstant.*;
 
@@ -28,6 +30,12 @@ public class CdcLifecycle {
 
 
     void onStart(@Observes StartupEvent ev) {
+
+        if(ConfigUtils.getProfiles().contains("test")) {
+            //Not perform any action when testing
+            return;
+        }
+
         log.info("The application is starting...");
 
         // Table CdCStartAt will be created

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserServiceImpl.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserServiceImpl.java
@@ -350,7 +350,11 @@ public class UserServiceImpl implements UserService {
                 .orElse(randomMailId.get());
 
         var workContact = UserUtils.buildWorkContact(userDto.getUser().getInstitutionEmail());
-        userResource.getWorkContacts().put(mailUuid, workContact);
+
+        // when update workContract on userRegistry we must create an empty map with only key that we want persist
+        Map<String, WorkContactResource> workContactToSave = new HashMap<>();
+        workContactToSave.put(mailUuid, workContact);
+        userResource.setWorkContacts(workContactToSave);
 
         return userRegistryApi.updateUsingPATCH(userResource.getId().toString(), userMapper.toMutableUserFieldsDto(userResource))
                 .onFailure().invoke(exception -> log.error("Error during update user on userRegistry: {} ", exception.getMessage(), exception))


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Update workContract on userRegistry we must create an empty map with only key that we want persist

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Update pdv brokes when user has a lot of mail and we try to pass to bdoy entire workContracts. Passing just one key, pdv will add this key inside workContracts.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.