### PR TITLE
[SELC-4777] hotfix: update user on pdv only when name/family/mail is changed

### DIFF
--- a/apps/user-ms/src/main/docs/openapi.json
+++ b/apps/user-ms/src/main/docs/openapi.json
@@ -49,11 +49,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -104,11 +104,11 @@
               "application/json" : { }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -184,11 +184,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -222,11 +222,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -317,11 +317,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -351,11 +351,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -396,11 +396,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -436,11 +436,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -486,11 +486,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -529,11 +529,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -576,11 +576,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -623,11 +623,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -672,11 +672,11 @@
           "204" : {
             "description" : "No Content"
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -733,11 +733,11 @@
               "application/json" : { }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -779,11 +779,11 @@
               "application/json" : { }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -819,11 +819,11 @@
               "application/json" : { }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -906,11 +906,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -956,11 +956,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -998,11 +998,11 @@
           "204" : {
             "description" : "No Content"
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -1186,6 +1186,7 @@
         }
       },
       "UpdateUserRequest" : {
+        "required" : [ "email" ],
         "type" : "object",
         "properties" : {
           "name" : {

--- a/apps/user-ms/src/main/docs/openapi.yaml
+++ b/apps/user-ms/src/main/docs/openapi.yaml
@@ -37,10 +37,10 @@ paths:
             application/json:
               schema:
                 type: boolean
-        "403":
-          description: Not Allowed
         "401":
           description: Not Authorized
+        "403":
+          description: Not Allowed
       security:
       - SecurityScheme: []
   /institutions/{institutionId}/products/{productId}/createdAt:
@@ -76,10 +76,10 @@ paths:
           description: OK
           content:
             application/json: {}
-        "403":
-          description: Not Allowed
         "401":
           description: Not Authorized
+        "403":
+          description: Not Allowed
       security:
       - SecurityScheme: []
   /institutions/{institutionId}/user-institutions:
@@ -130,10 +130,10 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/UserInstitutionResponse'
-        "403":
-          description: Not Allowed
         "401":
           description: Not Authorized
+        "403":
+          description: Not Allowed
       security:
       - SecurityScheme: []
   /institutions/{institutionId}/users:
@@ -156,10 +156,10 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/UserProductResponse'
-        "403":
-          description: Not Allowed
         "401":
           description: Not Authorized
+        "403":
+          description: Not Allowed
       security:
       - SecurityScheme: []
   /users:
@@ -222,10 +222,10 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/UserInstitutionResponse'
-        "403":
-          description: Not Allowed
         "401":
           description: Not Authorized
+        "403":
+          description: Not Allowed
       security:
       - SecurityScheme: []
     post:
@@ -245,10 +245,10 @@ paths:
             application/json:
               schema:
                 type: string
-        "403":
-          description: Not Allowed
         "401":
           description: Not Authorized
+        "403":
+          description: Not Allowed
       security:
       - SecurityScheme: []
   /users/emails:
@@ -276,10 +276,10 @@ paths:
                 type: array
                 items:
                   type: string
-        "403":
-          description: Not Allowed
         "401":
           description: Not Authorized
+        "403":
+          description: Not Allowed
       security:
       - SecurityScheme: []
   /users/ids:
@@ -303,10 +303,10 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/UserInstitutionResponse'
-        "403":
-          description: Not Allowed
         "401":
           description: Not Authorized
+        "403":
+          description: Not Allowed
       security:
       - SecurityScheme: []
   /users/notification:
@@ -338,10 +338,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UsersNotificationResponse'
-        "403":
-          description: Not Allowed
         "401":
           description: Not Authorized
+        "403":
+          description: Not Allowed
       security:
       - SecurityScheme: []
   /users/search:
@@ -366,10 +366,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UserDetailResponse'
-        "403":
-          description: Not Allowed
         "401":
           description: Not Authorized
+        "403":
+          description: Not Allowed
       security:
       - SecurityScheme: []
   /users/{id}:
@@ -398,10 +398,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UserResponse'
-        "403":
-          description: Not Allowed
         "401":
           description: Not Authorized
+        "403":
+          description: Not Allowed
       security:
       - SecurityScheme: []
   /users/{id}/details:
@@ -431,10 +431,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UserDetailResponse'
-        "403":
-          description: Not Allowed
         "401":
           description: Not Authorized
+        "403":
+          description: Not Allowed
       security:
       - SecurityScheme: []
   /users/{id}/institution/{institutionId}/product/{productId}/status:
@@ -466,10 +466,10 @@ paths:
       responses:
         "204":
           description: No Content
-        "403":
-          description: Not Allowed
         "401":
           description: Not Authorized
+        "403":
+          description: Not Allowed
       security:
       - SecurityScheme: []
   /users/{id}/status:
@@ -509,10 +509,10 @@ paths:
           description: OK
           content:
             application/json: {}
-        "403":
-          description: Not Allowed
         "401":
           description: Not Authorized
+        "403":
+          description: Not Allowed
       security:
       - SecurityScheme: []
   /users/{id}/user-registry:
@@ -541,10 +541,10 @@ paths:
           description: OK
           content:
             application/json: {}
-        "403":
-          description: Not Allowed
         "401":
           description: Not Authorized
+        "403":
+          description: Not Allowed
       security:
       - SecurityScheme: []
   /users/{userId}:
@@ -569,10 +569,10 @@ paths:
           description: OK
           content:
             application/json: {}
-        "403":
-          description: Not Allowed
         "401":
           description: Not Authorized
+        "403":
+          description: Not Allowed
       security:
       - SecurityScheme: []
   /users/{userId}/institution/{institutionId}:
@@ -633,10 +633,10 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/UserDataResponse'
-        "403":
-          description: Not Allowed
         "401":
           description: Not Authorized
+        "403":
+          description: Not Allowed
       security:
       - SecurityScheme: []
   /users/{userId}/institutions:
@@ -667,10 +667,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UserInfoResponse'
-        "403":
-          description: Not Allowed
         "401":
           description: Not Authorized
+        "403":
+          description: Not Allowed
       security:
       - SecurityScheme: []
   /users/{userId}/institutions/{institutionId}/products/{productId}:
@@ -697,10 +697,10 @@ paths:
       responses:
         "204":
           description: No Content
-        "403":
-          description: Not Allowed
         "401":
           description: Not Authorized
+        "403":
+          description: Not Allowed
       security:
       - SecurityScheme: []
 components:
@@ -856,6 +856,8 @@ components:
         fiscalCode:
           type: string
     UpdateUserRequest:
+      required:
+      - email
       type: object
       properties:
         name:

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/mapper/UserMapper.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/mapper/UserMapper.java
@@ -89,12 +89,12 @@ public interface UserMapper {
     }
     MutableUserFieldsDto toMutableUserFieldsDto(UserResource userResource);
 
-    @Mapping(source = "updateUserRequest.familyName", target = "familyName",  qualifiedByName = "toCertifiableString")
-    @Mapping(source = "updateUserRequest.name", target = "name",  qualifiedByName = "toCertifiableString")
+    @Mapping(target = "familyName",  expression = "java(toCertifiableStringNotEquals(userResource.getFamilyName(), updateUserRequest.getFamilyName()))")
+    @Mapping(target = "name",  expression = "java(toCertifiableStringNotEquals(userResource.getName(), updateUserRequest.getName()))")
     @Mapping(target = "workContacts",  expression = "java(toWorkContact(updateUserRequest.getEmail(), idMail))")
     @Mapping(target = "email", ignore = true)
     @Mapping(target = "birthDate", ignore = true)
-    MutableUserFieldsDto toMutableUserFieldsDto(UpdateUserRequest updateUserRequest, String idMail);
+    MutableUserFieldsDto toMutableUserFieldsDto(UpdateUserRequest updateUserRequest, UserResource userResource, String idMail);
 
     @Mapping(source = "user.birthDate", target = "birthDate", qualifiedByName = "toCertifiableLocalDate")
     @Mapping(source = "user.familyName", target = "familyName",  qualifiedByName = "toCertifiableString")
@@ -124,6 +124,22 @@ public interface UserMapper {
     @Named("toCertifiableString")
     default CertifiableFieldResourceOfstring toCertString(String value) {
         if (StringUtils.isNotBlank(value)){
+            var certifiableFieldResourceOfstring = new CertifiableFieldResourceOfstring();
+            certifiableFieldResourceOfstring.setValue(value);
+            certifiableFieldResourceOfstring.setCertification(CertifiableFieldResourceOfstring.CertificationEnum.NONE);
+            return certifiableFieldResourceOfstring;
+        }
+        return null;
+    }
+
+    @Named("toCertifiableStringNotEquals")
+    default CertifiableFieldResourceOfstring toCertifiableStringNotEquals(CertifiableFieldResourceOfstring certifiableString, String value) {
+        if(StringUtils.isBlank(value) ||
+                Objects.nonNull(certifiableString) && CertifiableFieldResourceOfstring.CertificationEnum.SPID.equals(certifiableString.getCertification())){
+            return null;
+        }
+
+        if(Objects.isNull(certifiableString) || !value.equals(certifiableString.getValue())){
             var certifiableFieldResourceOfstring = new CertifiableFieldResourceOfstring();
             certifiableFieldResourceOfstring.setValue(value);
             certifiableFieldResourceOfstring.setCertification(CertifiableFieldResourceOfstring.CertificationEnum.NONE);

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/model/UpdateUserRequest.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/model/UpdateUserRequest.java
@@ -1,10 +1,12 @@
 package it.pagopa.selfcare.user.model;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
 public class UpdateUserRequest {
     private String name;
     private String familyName;
+    @NotNull
     private String email;
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserRegistryServiceImpl.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserRegistryServiceImpl.java
@@ -2,7 +2,6 @@ package it.pagopa.selfcare.user.service;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.tuples.Tuple2;
 import it.pagopa.selfcare.user.constant.QueueEvent;
 import it.pagopa.selfcare.user.entity.UserInstitution;
 import it.pagopa.selfcare.user.entity.filter.UserInstitutionFilter;
@@ -16,14 +15,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.gradle.internal.impldep.org.apache.commons.lang.StringUtils;
-import org.openapi.quarkus.user_registry_json.model.MutableUserFieldsDto;
 
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.Flow;
+import java.util.*;
 
 import org.openapi.quarkus.user_registry_json.api.UserApi;
 import org.openapi.quarkus.user_registry_json.model.UserResource;
+
+import static it.pagopa.selfcare.user.constant.CollectionUtil.MAIL_ID_PREFIX;
 
 
 @ApplicationScoped
@@ -47,6 +45,10 @@ public class UserRegistryServiceImpl implements UserRegistryService {
     public Uni<List<UserNotificationToSend>> updateUserRegistryAndSendNotificationToQueue(UpdateUserRequest updateUserRequest, String userId, String institutionId) {
         log.trace("sendUpdateUserNotification start");
         log.debug("sendUpdateUserNotification userId = {}, institutionId = {}", userId, institutionId);
+
+        if(StringUtils.isBlank(updateUserRequest.getEmail()))
+            throw new IllegalArgumentException("email updateUserRequest must not be null!");
+
         UserInstitutionFilter userInstitutionFilter = UserInstitutionFilter.builder()
                 .userId(userId)
                 .institutionId(StringUtils.isNotBlank(institutionId) ? institutionId : null).build();
@@ -55,37 +57,38 @@ public class UserRegistryServiceImpl implements UserRegistryService {
                 .unis(userRegistryApi.findByIdUsingGET(USERS_FIELD_LIST_WITHOUT_FISCAL_CODE, userId),
                         userInstitutionService.findAllWithFilter(userInstitutionFilter.constructMap()).collect().asList())
                 .asTuple()
-                .onItem().transformToMulti(tuple -> checkEmail(tuple.getItem1(), updateUserRequest)
-                        .onItem().transformToMulti(idMail -> updateUserInstitutionAndSendNotification(tuple, idMail, userId)))
+                .onItem().transformToMulti(tuple -> findMailUuidAndUpdateUserRegistry(tuple.getItem1(), updateUserRequest)
+                        .onItem().transformToMulti(uuidMail -> updateUserInstitutionAndSendNotification(tuple.getItem1(), tuple.getItem2(), uuidMail)))
                 .collect().asList();
     }
 
-    private Multi<UserNotificationToSend> updateUserInstitutionAndSendNotification(Tuple2<UserResource, List<UserInstitution>> tuple, String idMail, String userId) {
-        return Multi.createFrom().iterable(tuple.getItem2().stream()
-                        .peek(userInstitution -> userInstitution.setUserMailUuid(idMail))
+    private Multi<UserNotificationToSend> updateUserInstitutionAndSendNotification(UserResource userResource, List<UserInstitution> userInstitutions, String mailUuid) {
+        return Multi.createFrom().iterable(userInstitutions.stream()
+                        .peek(userInstitution -> userInstitution.setUserMailUuid(mailUuid))
                         .toList())
                 .onItem().transformToUniAndMerge(userInstitutionService::persistOrUpdate)
-                .onItem().transformToMultiAndMerge(userInstitution -> sendKafkaNotification(tuple.getItem1(), userId, userInstitution));
+                .onItem().transformToMultiAndMerge(userInstitution -> sendKafkaNotification(userResource, userInstitution));
     }
 
-    private Multi<UserNotificationToSend> sendKafkaNotification(UserResource userResource, String userId, UserInstitution userInstitution) {
+    private Multi<UserNotificationToSend> sendKafkaNotification(UserResource userResource, UserInstitution userInstitution) {
         return Multi.createFrom().iterable(userUtils.buildUsersNotificationResponse(userInstitution, userResource, QueueEvent.UPDATE))
-                .onItem().transformToUniAndMerge(userNotificationToSend -> userNotificationService.sendKafkaNotification(userNotificationToSend, userId));
+                .onItem().transformToUniAndMerge(userNotificationToSend -> userNotificationService.sendKafkaNotification(userNotificationToSend, userResource.getId().toString()));
     }
 
-    private Uni<String> checkEmail(UserResource userResource, UpdateUserRequest userDto) {
-        return userResource.getWorkContacts().entrySet().stream()
-                .filter(entry -> entry.getValue() != null && entry.getValue().getEmail() != null && StringUtils.isNotBlank(entry.getValue().getEmail().getValue())
-                        && entry.getValue().getEmail().getValue().equalsIgnoreCase(userDto.getEmail()) && entry.getKey().startsWith("ID_MAIL#"))
-                .findFirst()
-                .map(entry -> {
-                    log.debug("Email already present in the user registry");
-                    return userRegistryApi.updateUsingPATCH(userResource.getId().toString(), userMapper.toMutableUserFieldsDto(userDto, null)).replaceWith(entry.getKey());
-                })
-                .orElseGet(() -> {
-                    String idMail = "ID_MAIL#" + UUID.randomUUID();
-                    return userRegistryApi.updateUsingPATCH(userResource.getId().toString(), userMapper.toMutableUserFieldsDto(userDto, idMail)).replaceWith(idMail);
-                });
+    private Uni<String> findMailUuidAndUpdateUserRegistry(UserResource userResource, UpdateUserRequest userDto) {
+        Optional<String> mailAlreadyPresent = Optional.empty();
+        String idMail = MAIL_ID_PREFIX + UUID.randomUUID();
 
+        if(Objects.nonNull(userResource.getWorkContacts())) {
+            mailAlreadyPresent = userResource.getWorkContacts().entrySet().stream()
+                    .filter(entry -> entry.getValue() != null && entry.getValue().getEmail() != null && StringUtils.isNotBlank(entry.getValue().getEmail().getValue())
+                            && entry.getValue().getEmail().getValue().equalsIgnoreCase(userDto.getEmail()) && entry.getKey().startsWith(MAIL_ID_PREFIX))
+                    .findFirst()
+                    .map(Map.Entry::getKey);
+        }
+
+        return userRegistryApi.updateUsingPATCH(userResource.getId().toString(),
+                userMapper.toMutableUserFieldsDto(userDto, userResource, mailAlreadyPresent.isPresent() ? null : idMail))
+            .replaceWith(mailAlreadyPresent.orElse(idMail));
     }
 }

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserRegistryServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserRegistryServiceTest.java
@@ -18,14 +18,17 @@ import org.bson.types.ObjectId;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.openapi.quarkus.user_registry_json.model.MutableUserFieldsDto;
 
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static io.smallrye.common.constraint.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @QuarkusTest
 @QuarkusTestResource(MongoTestResource.class)
@@ -44,7 +47,9 @@ public class UserRegistryServiceTest {
     private org.openapi.quarkus.user_registry_json.api.UserApi userRegistryApi;
 
     private static final String USERS_FIELD_LIST_WITHOUT_FISCAL_CODE = "name,familyName,email,workContacts";
-    private static org.openapi.quarkus.user_registry_json.model.UserResource userResource;
+    private static final org.openapi.quarkus.user_registry_json.model.UserResource userResource;
+    private static final String userMailDefault = "test@test.it";
+    private static final String userMailUuidDefault = "ID_MAIL#123455";
     private static UserInstitution userInstitution;
 
     static {
@@ -56,11 +61,11 @@ public class UserRegistryServiceTest {
         userResource.setFamilyName(certifiedName);
         userResource.setFiscalCode("taxCode");
         org.openapi.quarkus.user_registry_json.model.CertifiableFieldResourceOfstring certifiedEmail = new org.openapi.quarkus.user_registry_json.model.CertifiableFieldResourceOfstring();
-        certifiedEmail.setValue("test@test.it");
+        certifiedEmail.setValue(userMailDefault);
         org.openapi.quarkus.user_registry_json.model.WorkContactResource workContactResource = new org.openapi.quarkus.user_registry_json.model.WorkContactResource();
         workContactResource.setEmail(certifiedEmail);
         userResource.setEmail(certifiedEmail);
-        userResource.setWorkContacts(Map.of("ID_MAIL#123455", workContactResource));
+        userResource.setWorkContacts(Map.of(userMailUuidDefault, workContactResource));
 
         userInstitution = new UserInstitution();
         userInstitution.setId(ObjectId.get());
@@ -78,16 +83,90 @@ public class UserRegistryServiceTest {
     }
 
     @Test
+    void updateUserRegistryAndSendNotificationToQueue_shouldThrowExceptionWhenMailIsNull() {
+        assertThrows(IllegalArgumentException.class, () -> userRegistryService.updateUserRegistryAndSendNotificationToQueue(new UpdateUserRequest(), null, null));
+    }
+
+    @Test
+    void updateUserRegistryAndSendNotificationToQueue_whenUserRegistryNothingToUpdate() {
+        final String userId = userResource.getId().toString();
+        final String institutionId = "institutionId";
+        when(userNotificationService.sendKafkaNotification(any(UserNotificationToSend.class), anyString())).thenReturn(Uni.createFrom().item(new UserNotificationToSend()));
+
+        UpdateUserRequest updateUserRequest = new UpdateUserRequest();
+        updateUserRequest.setName(userResource.getName().getValue());
+        updateUserRequest.setEmail(userMailDefault);
+
+        when(userInstitutionService.findAllWithFilter(anyMap())).thenReturn(Multi.createFrom().item(userInstitution));
+        when(userInstitutionService.persistOrUpdate(any(UserInstitution.class))).thenReturn(Uni.createFrom().item(userInstitution));
+        when(userRegistryApi.updateUsingPATCH(eq(userId), any(MutableUserFieldsDto.class))).thenReturn(Uni.createFrom().item(Response.accepted().build()));
+        when(userRegistryApi.findByIdUsingGET(USERS_FIELD_LIST_WITHOUT_FISCAL_CODE, userId)).thenReturn(Uni.createFrom().item(userResource));
+
+        UniAssertSubscriber<List<UserNotificationToSend>> subscriber = userRegistryService.updateUserRegistryAndSendNotificationToQueue(updateUserRequest, userId, institutionId)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.assertCompleted();
+
+        ArgumentCaptor<MutableUserFieldsDto> userFieldsDtoArgumentCaptor = ArgumentCaptor.forClass(MutableUserFieldsDto.class);
+        verify(userRegistryApi, times(1))
+                .updateUsingPATCH(eq(userId), userFieldsDtoArgumentCaptor.capture());
+        assertNull(userFieldsDtoArgumentCaptor.getValue().getName());
+
+        ArgumentCaptor<UserInstitution> userInstitutionArgumentCaptor = ArgumentCaptor.forClass(UserInstitution.class);
+        verify(userInstitutionService, times(1))
+                .persistOrUpdate(userInstitutionArgumentCaptor.capture());
+        assertEquals(userMailUuidDefault, userInstitutionArgumentCaptor.getValue().getUserMailUuid());
+    }
+
+    @Test
+    void updateUserRegistryAndSendNotificationToQueue_whenUserRegistryMustUpdate() {
+        final String userId = userResource.getId().toString();
+        final String institutionId = "institutionId";
+        when(userNotificationService.sendKafkaNotification(any(UserNotificationToSend.class), anyString())).thenReturn(Uni.createFrom().item(new UserNotificationToSend()));
+
+        UpdateUserRequest updateUserRequest = new UpdateUserRequest();
+        updateUserRequest.setName("example");
+        updateUserRequest.setEmail("example@example.it");
+
+        when(userInstitutionService.findAllWithFilter(anyMap())).thenReturn(Multi.createFrom().item(userInstitution));
+        when(userInstitutionService.persistOrUpdate(any(UserInstitution.class))).thenReturn(Uni.createFrom().item(userInstitution));
+        when(userRegistryApi.updateUsingPATCH(eq(userId), any(MutableUserFieldsDto.class))).thenReturn(Uni.createFrom().item(Response.accepted().build()));
+        when(userRegistryApi.findByIdUsingGET(USERS_FIELD_LIST_WITHOUT_FISCAL_CODE, userId)).thenReturn(Uni.createFrom().item(userResource));
+
+        UniAssertSubscriber<List<UserNotificationToSend>> subscriber = userRegistryService.updateUserRegistryAndSendNotificationToQueue(updateUserRequest, userId, institutionId)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.assertCompleted();
+
+        //User should be updated for name and mail with a new MailUuid
+        ArgumentCaptor<MutableUserFieldsDto> userFieldsDtoArgumentCaptor = ArgumentCaptor.forClass(MutableUserFieldsDto.class);
+        verify(userRegistryApi, times(1))
+                .updateUsingPATCH(eq(userId), userFieldsDtoArgumentCaptor.capture());
+        assertEquals(updateUserRequest.getName(), userFieldsDtoArgumentCaptor.getValue().getName().getValue());
+        assertNotNull(userFieldsDtoArgumentCaptor.getValue().getWorkContacts());
+        final String userMailUuid = userFieldsDtoArgumentCaptor.getValue().getWorkContacts().keySet().stream().findFirst().orElse(null);
+        assertNotNull(userMailUuid);
+        assertEquals(updateUserRequest.getEmail(), userFieldsDtoArgumentCaptor.getValue().getWorkContacts().get(userMailUuid).getEmail().getValue());
+
+        //UserInstitution should update a new MailUuid
+        ArgumentCaptor<UserInstitution> userInstitutionArgumentCaptor = ArgumentCaptor.forClass(UserInstitution.class);
+        verify(userInstitutionService, times(1))
+                .persistOrUpdate(userInstitutionArgumentCaptor.capture());
+        assertEquals(userMailUuid, userInstitutionArgumentCaptor.getValue().getUserMailUuid());
+    }
+
+    @Test
     void testSendUpdateUserNotificationToQueue() {
+        final String userId = userResource.getId().toString();
+        final String institutionId = "institutionId";
         when(userNotificationService.sendKafkaNotification(any(UserNotificationToSend.class), anyString())).thenReturn(Uni.createFrom().item(new UserNotificationToSend()));
 
         UpdateUserRequest updateUserRequest = new UpdateUserRequest();
         updateUserRequest.setEmail("test2@test.it");
         when(userInstitutionService.findAllWithFilter(anyMap())).thenReturn(Multi.createFrom().item(userInstitution));
         when(userInstitutionService.persistOrUpdate(any(UserInstitution.class))).thenReturn(Uni.createFrom().item(userInstitution));
-        when(userRegistryApi.updateUsingPATCH(eq("userId"), any(MutableUserFieldsDto.class))).thenReturn(Uni.createFrom().item(Response.accepted().build()));
-        when(userRegistryApi.findByIdUsingGET(USERS_FIELD_LIST_WITHOUT_FISCAL_CODE, "userId")).thenReturn(Uni.createFrom().item(userResource));
-        UniAssertSubscriber<List<UserNotificationToSend>> subscriber = userRegistryService.updateUserRegistryAndSendNotificationToQueue(updateUserRequest, "userId", "institutionId")
+        when(userRegistryApi.updateUsingPATCH(eq(userId), any(MutableUserFieldsDto.class))).thenReturn(Uni.createFrom().item(Response.accepted().build()));
+        when(userRegistryApi.findByIdUsingGET(USERS_FIELD_LIST_WITHOUT_FISCAL_CODE, userId)).thenReturn(Uni.createFrom().item(userResource));
+
+        UniAssertSubscriber<List<UserNotificationToSend>> subscriber = userRegistryService.updateUserRegistryAndSendNotificationToQueue(updateUserRequest, userId, institutionId)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         subscriber.assertCompleted();
     }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

On POST /users/:id/user-registry endpoint:
* Avoid nullpointerexception checking id workContract is null
* Create object to update on PDV only if name/family/mail is really changed  and name/family is not SPID certified
* Refactor method improving readability 

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
nullpointerexception happens when user try to update an user without workContracts. In addition, an 409 error always occurs when user has name/family SPID value Certifiable. 


#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.