### PR TITLE
[SELC-4881] fix: User CDC create UserInfo if there are valid product

### DIFF
--- a/apps/user-cdc/src/main/java/it/pagopa/selfcare/user/event/repository/UserInstitutionRepository.java
+++ b/apps/user-cdc/src/main/java/it/pagopa/selfcare/user/event/repository/UserInstitutionRepository.java
@@ -40,18 +40,28 @@ public class UserInstitutionRepository {
     }
 
     private Uni<Void> createNewUserInfo(UserInstitution userInstitution) {
+        if(CollectionUtils.isEmpty(userInstitution.getProducts())){
+            return Uni.createFrom().voidItem();
+        }
+
+        List<UserInstitutionRole> institutionRoles = userInstitution.getProducts().stream()
+                .filter(product -> VALID_PRODUCT_STATE.contains(product.getStatus()))
+                .map(product -> userMapper.toUserInstitutionRole(userInstitution, product.getRole(), product.getStatus()))
+                .toList();
+
+        if(CollectionUtils.isEmpty(institutionRoles)){
+            return Uni.createFrom().voidItem();
+        }
+
         UserInfo userInfo = new UserInfo();
         userInfo.setUserId(userInstitution.getUserId());
         userInfo.setInstitutions(new ArrayList<>());
-        if(!CollectionUtils.isEmpty(userInstitution.getProducts())){
-            userInstitution.getProducts().forEach(product -> {
-                if (VALID_PRODUCT_STATE.contains(product.getStatus())) {
-                    PartyRole role = product.getRole();
-                    userInfo.getInstitutions().add(userMapper.toUserInstitutionRole(userInstitution, role, product.getStatus()));
-                }
-            });
-        }
-        return UserInfo.persistOrUpdate(userInfo).replaceWith(Uni.createFrom().voidItem());
+        userInfo.setInstitutions(institutionRoles);
+
+        return UserInfo.persistOrUpdate(userInfo)
+                .invoke(() -> log.info(String.format("createNewUserInfo for userId %s and institution %s",
+                        userInstitution.getUserId(),userInstitution.getInstitutionId())))
+                .replaceWith(Uni.createFrom().voidItem());
     }
 
     private Uni<Void> deleteInstitutionOrAllUserInfo(ReactivePanacheMongoEntityBase entityBase, UserInstitution userInstitution) {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* Create UserInfo only if valid product is present, otherwise it skip persisting UserInfo with institutions empty
* Fix adding institutions in case there are records UserInfo with institutions empty
* Unit tests more reliable

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Issue occurs in production env on a UserInfo has institutions empty., new records with ACTIVE role have not beed added

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.