### PR TITLE
[SELC-4935] fix: Prevent Duplication of Institutions in UserInfo Creation

### DIFF
--- a/apps/user-cdc/pom.xml
+++ b/apps/user-cdc/pom.xml
@@ -78,6 +78,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jacoco</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-vertx</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* Implemented a validation step in the UserInfo creation process to check for existing institutions before adding a new one.
* Modified the logic to iterate over UserInstitution records and take only one the record that have a validation state and the higher role in terms of permission

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This pull request addresses an issue in the **user-cdc** microservice where institutions could be duplicated when creating a UserInfo record. This duplication occurs if a UserInstitution record has more than one product in the **ACTIVE** state.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.