### PR TITLE
[SELC-4970] Feat: Refactor "/authorize" API to have institutionId as optional query param

### DIFF
--- a/apps/user-ms/src/main/docs/openapi.json
+++ b/apps/user-ms/src/main/docs/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi" : "3.0.3",
   "info" : {
-    "title" : "user-ms API",
+    "title" : "User API",
     "version" : "1.0.0"
   },
   "servers" : [ {
@@ -12,16 +12,14 @@
     "description" : "Auto generated value"
   } ],
   "paths" : {
-    "/authorize/{institutionId}" : {
+    "/authorize" : {
       "get" : {
         "tags" : [ "User Permission Controller" ],
         "summary" : "Get permission for a user in an institution",
         "parameters" : [ {
           "name" : "institutionId",
-          "in" : "path",
-          "required" : true,
+          "in" : "query",
           "schema" : {
-            "minLength" : 1,
             "type" : "string"
           }
         }, {

--- a/apps/user-ms/src/main/docs/openapi.yaml
+++ b/apps/user-ms/src/main/docs/openapi.yaml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.3
 info:
-  title: user-ms API
+  title: User API
   version: 1.0.0
 servers:
 - url: http://localhost:8080
@@ -9,17 +9,15 @@ servers:
 - url: http://0.0.0.0:8080
   description: Auto generated value
 paths:
-  /authorize/{institutionId}:
+  /authorize:
     get:
       tags:
       - User Permission Controller
       summary: Get permission for a user in an institution
       parameters:
       - name: institutionId
-        in: path
-        required: true
+        in: query
         schema:
-          minLength: 1
           type: string
       - name: permission
         in: query

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/constant/SelfCareRole.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/constant/SelfCareRole.java
@@ -1,18 +1,26 @@
 package it.pagopa.selfcare.user.constant;
 
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+@Getter
 public enum SelfCareRole {
     MANAGER(SelfCareAuthority.ADMIN),
     DELEGATE(SelfCareAuthority.ADMIN),
     SUB_DELEGATE(SelfCareAuthority.ADMIN),
     OPERATOR(SelfCareAuthority.LIMITED);
 
-    private SelfCareAuthority selfCareAuthority;
+    private final SelfCareAuthority selfCareAuthority;
 
     private SelfCareRole(SelfCareAuthority selfCareAuthority) {
         this.selfCareAuthority = selfCareAuthority;
     }
 
-    public SelfCareAuthority getSelfCareAuthority() {
-        return this.selfCareAuthority;
+    public static List<SelfCareRole> fromSelfCareAuthority(String selfCareAuthority) {
+        return Stream.of(SelfCareRole.values())
+                .filter(role -> role.getSelfCareAuthority().name().equals(selfCareAuthority))
+                .toList();
     }
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/UserPermissionController.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/UserPermissionController.java
@@ -35,10 +35,9 @@ public class UserPermissionController {
      */
     @Operation(summary = "Get permission for a user in an institution")
     @GET
-    @Path("/{institutionId}")
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<Boolean> getPermission(
-            @NotEmpty(message = "institutionId is required") @PathParam("institutionId") String institutionId,
+            @QueryParam("institutionId") String institutionId,
             @QueryParam("productId") String productId,
             @NotNull(message = "Permission type is required") @QueryParam("permission") PermissionTypeEnum permission,
             @Context SecurityContext ctx) {

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionService.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionService.java
@@ -4,6 +4,7 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
 import it.pagopa.selfcare.user.constant.OnboardedProductState;
+import it.pagopa.selfcare.user.constant.PermissionTypeEnum;
 import it.pagopa.selfcare.user.controller.response.UserInstitutionResponse;
 import it.pagopa.selfcare.user.entity.UserInstitution;
 
@@ -36,4 +37,6 @@ public interface UserInstitutionService {
     Uni<UserInstitution> findByUserIdAndInstitutionId(String userId, String institutionId);
 
     Uni<UserInstitution> persistOrUpdate(UserInstitution userInstitution);
+
+    Uni<Boolean> checkExistsValidUserProduct(String userId, String institutionId, String productId, PermissionTypeEnum permission);
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionService.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionService.java
@@ -38,5 +38,5 @@ public interface UserInstitutionService {
 
     Uni<UserInstitution> persistOrUpdate(UserInstitution userInstitution);
 
-    Uni<Boolean> checkExistsValidUserProduct(String userId, String institutionId, String productId, PermissionTypeEnum permission);
+    Uni<Boolean> existsValidUserProduct(String userId, String institutionId, String productId, PermissionTypeEnum permission);
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionServiceDefault.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionServiceDefault.java
@@ -187,7 +187,7 @@ public class UserInstitutionServiceDefault implements UserInstitutionService {
     }
 
     @Override
-    public Uni<Boolean> checkExistsValidUserProduct(String userId, String institutionId, String productId, PermissionTypeEnum permission) {
+    public Uni<Boolean> existsValidUserProduct(String userId, String institutionId, String productId, PermissionTypeEnum permission) {
 
         Map<String, Object> userInstitutionFilterMap = UserInstitutionFilter.builder().userId(userId).institutionId(institutionId).build().constructMap();
         OnboardedProductFilter.OnboardedProductFilterBuilder builder = OnboardedProductFilter.builder().productId(productId).status(List.of(ACTIVE, PENDING, TOBEVALIDATED));

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionServiceDefault.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionServiceDefault.java
@@ -5,6 +5,8 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
 import it.pagopa.selfcare.user.constant.OnboardedProductState;
+import it.pagopa.selfcare.user.constant.PermissionTypeEnum;
+import it.pagopa.selfcare.user.constant.SelfCareRole;
 import it.pagopa.selfcare.user.controller.response.UserInstitutionResponse;
 import it.pagopa.selfcare.user.entity.OnboardedProduct;
 import it.pagopa.selfcare.user.entity.UserInstitution;
@@ -23,7 +25,7 @@ import java.time.LocalDateTime;
 import java.util.*;
 
 import static it.pagopa.selfcare.user.constant.CollectionUtil.*;
-import static it.pagopa.selfcare.user.constant.OnboardedProductState.ACTIVE;
+import static it.pagopa.selfcare.user.constant.OnboardedProductState.*;
 import static it.pagopa.selfcare.user.entity.filter.OnboardedProductFilter.OnboardedProductEnum.*;
 import static it.pagopa.selfcare.user.util.GeneralUtils.formatQueryParameterList;
 
@@ -184,6 +186,21 @@ public class UserInstitutionServiceDefault implements UserInstitutionService {
                 .replaceWith(userInstitution);
     }
 
+    @Override
+    public Uni<Boolean> checkExistsValidUserProduct(String userId, String institutionId, String productId, PermissionTypeEnum permission) {
+
+        Map<String, Object> userInstitutionFilterMap = UserInstitutionFilter.builder().userId(userId).institutionId(institutionId).build().constructMap();
+        OnboardedProductFilter.OnboardedProductFilterBuilder builder = OnboardedProductFilter.builder().productId(productId).status(List.of(ACTIVE, PENDING, TOBEVALIDATED));
+        if (permission.equals(PermissionTypeEnum.ADMIN)) {
+            builder.role(SelfCareRole.fromSelfCareAuthority(permission.name()));
+        }
+        Map<String, Object> onboardedProductFilterMap = builder.build().constructMap();
+        Map<String, Object> filterMap = userUtils.retrieveMapForFilter(userInstitutionFilterMap, onboardedProductFilterMap);
+        Document query = queryUtils.buildQueryDocument(filterMap, USER_INSTITUTION_COLLECTION);
+
+        return runUserInstitutionCountQuery(query);
+    }
+
 
     private boolean productFilterIsEmpty(Map<String, Object> filterMap) {
         return !filterMap.containsKey(PRODUCT_ID.getChild())
@@ -193,5 +210,10 @@ public class UserInstitutionServiceDefault implements UserInstitutionService {
 
     public ReactivePanacheQuery<UserInstitution> runUserInstitutionFindQuery(Document query, Document sort) {
         return UserInstitution.find(query, sort);
+    }
+
+    public Uni<Boolean> runUserInstitutionCountQuery(Document query) {
+        Uni<Long> count = UserInstitution.count(query);
+        return count.onItem().transform(c -> c > 0);
     }
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserPermissionService.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserPermissionService.java
@@ -4,5 +4,5 @@ import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.user.constant.PermissionTypeEnum;
 
 public interface UserPermissionService {
-     Uni<Boolean>hasPermission(String institutionId, String productId, PermissionTypeEnum permission, String userId);
+     Uni<Boolean> hasPermission(String institutionId, String productId, PermissionTypeEnum permission, String userId);
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserPermissionServiceImpl.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserPermissionServiceImpl.java
@@ -2,21 +2,9 @@ package it.pagopa.selfcare.user.service;
 
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.user.constant.PermissionTypeEnum;
-import it.pagopa.selfcare.user.constant.SelfCareRole;
-import it.pagopa.selfcare.user.entity.UserInstitution;
-import it.pagopa.selfcare.user.entity.filter.OnboardedProductFilter;
-import it.pagopa.selfcare.user.entity.filter.UserInstitutionFilter;
-import it.pagopa.selfcare.user.exception.ResourceNotFoundException;
-import it.pagopa.selfcare.user.util.UserUtils;
 import jakarta.enterprise.context.ApplicationScoped;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
-
-import java.util.Map;
-
-import static it.pagopa.selfcare.user.constant.CustomError.USER_INSTITUTION_NOT_FOUND_ERROR;
-import static it.pagopa.selfcare.user.constant.CustomError.USER_NOT_FOUND_ERROR;
 
 @Slf4j
 @ApplicationScoped
@@ -24,33 +12,12 @@ import static it.pagopa.selfcare.user.constant.CustomError.USER_NOT_FOUND_ERROR;
 public class UserPermissionServiceImpl implements UserPermissionService {
 
     private final UserInstitutionService userInstitutionService;
-    private final UserUtils userUtils;
 
     @Override
     public Uni<Boolean> hasPermission(String institutionId, String productId, PermissionTypeEnum permission, String userId) {
         log.trace("hasPermission start");
         log.debug("check permission {} for userId: {}, institutionId: {} and productId: {}", permission, userId, institutionId, productId);
 
-        return retrievePerson(userId, productId, institutionId)
-                .onItem().ifNotNull().invoke(userInstitution -> log.debug("UserInstitution founded for given parameters"))
-                .onItem().transform(userInstitution -> PermissionTypeEnum.ANY.equals(permission) || checkProductRole(userInstitution, productId, permission))
-                .onFailure(ResourceNotFoundException.class).recoverWithItem(false);
-    }
-
-    private boolean checkProductRole(UserInstitution userInstitution, String productId, PermissionTypeEnum permission) {
-        return userInstitution.getProducts().stream()
-                .anyMatch(product -> permission.name().equalsIgnoreCase(SelfCareRole.valueOf(product.getRole().name()).getSelfCareAuthority().name()) &&
-                        (StringUtils.isBlank(productId) || product.getProductId().equalsIgnoreCase(productId)));
-    }
-
-    private Uni<UserInstitution> retrievePerson(String userId, String productId, String institutionId) {
-        var userInstitutionFilters = UserInstitutionFilter.builder().userId(userId).institutionId(institutionId).build().constructMap();
-        var productFilters = OnboardedProductFilter.builder().productId(productId).build().constructMap();
-        Map<String, Object> queryParameter = userUtils.retrieveMapForFilter(userInstitutionFilters, productFilters);
-        return userInstitutionService.retrieveFirstFilteredUserInstitution(queryParameter)
-                .onItem().ifNull().failWith(() -> {
-                    log.error(String.format(USER_INSTITUTION_NOT_FOUND_ERROR.getMessage(), userId, institutionId));
-                    return new ResourceNotFoundException(String.format(USER_INSTITUTION_NOT_FOUND_ERROR.getMessage(), userId, institutionId), USER_NOT_FOUND_ERROR.getCode());
-                });
+        return userInstitutionService.checkExistsValidUserProduct(userId, institutionId, productId, permission);
     }
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserPermissionServiceImpl.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserPermissionServiceImpl.java
@@ -18,6 +18,6 @@ public class UserPermissionServiceImpl implements UserPermissionService {
         log.trace("hasPermission start");
         log.debug("check permission {} for userId: {}, institutionId: {} and productId: {}", permission, userId, institutionId, productId);
 
-        return userInstitutionService.checkExistsValidUserProduct(userId, institutionId, productId, permission);
+        return userInstitutionService.existsValidUserProduct(userId, institutionId, productId, permission);
     }
 }

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserInstitutionServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserInstitutionServiceTest.java
@@ -65,7 +65,7 @@ class UserInstitutionServiceTest {
         when(UserInstitution.count(embeddedCaptor.capture()))
                 .thenReturn(Uni.createFrom().item(0L));
         UniAssertSubscriber<Boolean> subscriber = userInstitutionService
-                .checkExistsValidUserProduct(userId, institutionId, null, PermissionTypeEnum.ANY)
+                .existsValidUserProduct(userId, institutionId, null, PermissionTypeEnum.ANY)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("institutionId"));
         Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("productId"));
@@ -82,7 +82,7 @@ class UserInstitutionServiceTest {
         when(UserInstitution.count(embeddedCaptor.capture()))
                 .thenReturn(Uni.createFrom().item(1L));
         UniAssertSubscriber<Boolean> subscriber = userInstitutionService
-                .checkExistsValidUserProduct(userId, institutionId, null, PermissionTypeEnum.ADMIN)
+                .existsValidUserProduct(userId, institutionId, null, PermissionTypeEnum.ADMIN)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("institutionId"));
         Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("productId"));
@@ -98,7 +98,7 @@ class UserInstitutionServiceTest {
         when(UserInstitution.count(embeddedCaptor.capture()))
                 .thenReturn(Uni.createFrom().item(1L));
         UniAssertSubscriber<Boolean> subscriber = userInstitutionService
-                .checkExistsValidUserProduct(userId, institutionId, null, PermissionTypeEnum.ANY)
+                .existsValidUserProduct(userId, institutionId, null, PermissionTypeEnum.ANY)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("institutionId"));
         Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("productId"));
@@ -115,7 +115,7 @@ class UserInstitutionServiceTest {
         when(UserInstitution.count(embeddedCaptor.capture()))
                 .thenReturn(Uni.createFrom().item(0L));
         UniAssertSubscriber<Boolean> subscriber = userInstitutionService
-                .checkExistsValidUserProduct(userId, institutionId, null, PermissionTypeEnum.ADMIN)
+                .existsValidUserProduct(userId, institutionId, null, PermissionTypeEnum.ADMIN)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("institutionId"));
         Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("productId"));
@@ -132,7 +132,7 @@ class UserInstitutionServiceTest {
         when(UserInstitution.count(embeddedCaptor.capture()))
                 .thenReturn(Uni.createFrom().item(0L));
         UniAssertSubscriber<Boolean> subscriber = userInstitutionService
-                .checkExistsValidUserProduct(userId, null, productId, PermissionTypeEnum.ADMIN)
+                .existsValidUserProduct(userId, null, productId, PermissionTypeEnum.ADMIN)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("institutionId"));
         Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("productId"));
@@ -149,7 +149,7 @@ class UserInstitutionServiceTest {
         when(UserInstitution.count(embeddedCaptor.capture()))
                 .thenReturn(Uni.createFrom().item(0L));
         UniAssertSubscriber<Boolean> subscriber = userInstitutionService
-                .checkExistsValidUserProduct(userId, null, productId, PermissionTypeEnum.ANY)
+                .existsValidUserProduct(userId, null, productId, PermissionTypeEnum.ANY)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("institutionId"));
         Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("productId"));
@@ -166,7 +166,7 @@ class UserInstitutionServiceTest {
         when(UserInstitution.count(embeddedCaptor.capture()))
                 .thenReturn(Uni.createFrom().item(1L));
         UniAssertSubscriber<Boolean> subscriber = userInstitutionService
-                .checkExistsValidUserProduct(userId, null, productId, PermissionTypeEnum.ADMIN)
+                .existsValidUserProduct(userId, null, productId, PermissionTypeEnum.ADMIN)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("institutionId"));
         Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("productId"));
@@ -182,7 +182,7 @@ class UserInstitutionServiceTest {
         when(UserInstitution.count(embeddedCaptor.capture()))
                 .thenReturn(Uni.createFrom().item(1L));
         UniAssertSubscriber<Boolean> subscriber = userInstitutionService
-                .checkExistsValidUserProduct(userId, null, productId, PermissionTypeEnum.ANY)
+                .existsValidUserProduct(userId, null, productId, PermissionTypeEnum.ANY)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("institutionId"));
         Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("productId"));
@@ -200,7 +200,7 @@ class UserInstitutionServiceTest {
         when(UserInstitution.count(embeddedCaptor.capture()))
                 .thenReturn(Uni.createFrom().item(0L));
         UniAssertSubscriber<Boolean> subscriber = userInstitutionService
-                .checkExistsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ADMIN)
+                .existsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ADMIN)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("institutionId"));
         Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("productId"));
@@ -218,7 +218,7 @@ class UserInstitutionServiceTest {
         when(UserInstitution.count(embeddedCaptor.capture()))
                 .thenReturn(Uni.createFrom().item(0L));
         UniAssertSubscriber<Boolean> subscriber = userInstitutionService
-                .checkExistsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ANY)
+                .existsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ANY)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("institutionId"));
         Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("productId"));
@@ -237,7 +237,7 @@ class UserInstitutionServiceTest {
                 .thenReturn(Uni.createFrom().item(1L));
 
         UniAssertSubscriber<Boolean> subscriber = userInstitutionService
-                .checkExistsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ADMIN)
+                .existsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ADMIN)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
         Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("institutionId"));
@@ -256,7 +256,7 @@ class UserInstitutionServiceTest {
         when(UserInstitution.count(embeddedCaptor.capture()))
                 .thenReturn(Uni.createFrom().item(1L));
         UniAssertSubscriber<Boolean> subscriber = userInstitutionService
-                .checkExistsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ANY)
+                .existsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ANY)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("institutionId"));
         Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("productId"));

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserInstitutionServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserInstitutionServiceTest.java
@@ -4,7 +4,6 @@ import io.quarkus.mongodb.panache.common.reactive.ReactivePanacheUpdate;
 import io.quarkus.mongodb.panache.reactive.ReactivePanacheQuery;
 import io.quarkus.panache.mock.PanacheMock;
 import io.quarkus.test.InjectMock;
-import io.quarkus.test.Mock;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.mongodb.MongoTestResource;
@@ -16,6 +15,7 @@ import it.pagopa.selfcare.onboarding.common.PartyRole;
 import it.pagopa.selfcare.product.entity.ProductRole;
 import it.pagopa.selfcare.product.service.ProductService;
 import it.pagopa.selfcare.user.constant.OnboardedProductState;
+import it.pagopa.selfcare.user.constant.PermissionTypeEnum;
 import it.pagopa.selfcare.user.controller.response.UserInstitutionResponse;
 import it.pagopa.selfcare.user.entity.OnboardedProduct;
 import it.pagopa.selfcare.user.entity.UserInstitution;
@@ -24,19 +24,16 @@ import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static io.smallrye.common.constraint.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @QuarkusTest
 @QuarkusTestResource(MongoTestResource.class)
@@ -57,6 +54,213 @@ class UserInstitutionServiceTest {
                 .thenReturn(Uni.createFrom().item(userInstitution));
         Uni<UserInstitutionResponse> response = userInstitutionService.findById(id);
         Assertions.assertNotNull(response);
+    }
+
+    @Test
+    public void checkExistsValidUserProductAnyWithoutProductId() {
+        String userId = "userId";
+        String institutionId = "institutionId";
+        PanacheMock.mock(UserInstitution.class);
+        ArgumentCaptor<Document> embeddedCaptor = ArgumentCaptor.forClass(Document.class);
+        when(UserInstitution.count(embeddedCaptor.capture()))
+                .thenReturn(Uni.createFrom().item(0L));
+        UniAssertSubscriber<Boolean> subscriber = userInstitutionService
+                .checkExistsValidUserProduct(userId, institutionId, null, PermissionTypeEnum.ANY)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("institutionId"));
+        Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("productId"));
+        Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("role"));
+        subscriber.assertCompleted().assertItem(false);
+    }
+
+    @Test
+    public void checkExistProductIdByRoleAdminWithoutProductId() {
+        String userId = "userId";
+        String institutionId = "institutionId";
+        PanacheMock.mock(UserInstitution.class);
+        ArgumentCaptor<Document> embeddedCaptor = ArgumentCaptor.forClass(Document.class);
+        when(UserInstitution.count(embeddedCaptor.capture()))
+                .thenReturn(Uni.createFrom().item(1L));
+        UniAssertSubscriber<Boolean> subscriber = userInstitutionService
+                .checkExistsValidUserProduct(userId, institutionId, null, PermissionTypeEnum.ADMIN)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("institutionId"));
+        Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("productId"));
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("role"));
+        subscriber.assertCompleted().assertItem(true);    }
+
+    @Test
+    public void checkExistProductIdByRoleAnyWithoutProductId() {
+        String institutionId = "institutionId";
+        String userId = "userId";
+        PanacheMock.mock(UserInstitution.class);
+        ArgumentCaptor<Document> embeddedCaptor = ArgumentCaptor.forClass(Document.class);
+        when(UserInstitution.count(embeddedCaptor.capture()))
+                .thenReturn(Uni.createFrom().item(1L));
+        UniAssertSubscriber<Boolean> subscriber = userInstitutionService
+                .checkExistsValidUserProduct(userId, institutionId, null, PermissionTypeEnum.ANY)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("institutionId"));
+        Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("productId"));
+        Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("role"));
+        subscriber.assertCompleted().assertItem(true);
+    }
+
+    @Test
+    public void checkExistsValidUserProductAdminWithoutProductId() {
+        String institutionId = "institutionId";
+        String userId = "userId";
+        PanacheMock.mock(UserInstitution.class);
+        ArgumentCaptor<Document> embeddedCaptor = ArgumentCaptor.forClass(Document.class);
+        when(UserInstitution.count(embeddedCaptor.capture()))
+                .thenReturn(Uni.createFrom().item(0L));
+        UniAssertSubscriber<Boolean> subscriber = userInstitutionService
+                .checkExistsValidUserProduct(userId, institutionId, null, PermissionTypeEnum.ADMIN)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("institutionId"));
+        Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("productId"));
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("role"));
+        subscriber.assertCompleted().assertItem(false);
+    }
+
+    @Test
+    public void checkExistsValidUserProductAdminWithoutInstitutionId() {
+        String userId = "userId";
+        String productId = "productId";
+        PanacheMock.mock(UserInstitution.class);
+        ArgumentCaptor<Document> embeddedCaptor = ArgumentCaptor.forClass(Document.class);
+        when(UserInstitution.count(embeddedCaptor.capture()))
+                .thenReturn(Uni.createFrom().item(0L));
+        UniAssertSubscriber<Boolean> subscriber = userInstitutionService
+                .checkExistsValidUserProduct(userId, null, productId, PermissionTypeEnum.ADMIN)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("institutionId"));
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("productId"));
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("role"));
+        subscriber.assertCompleted().assertItem(false);
+    }
+
+    @Test
+    public void checkExistsValidUserProductAnyWithoutInstitutionId() {
+        String userId = "userId";
+        String productId = "productId";
+        PanacheMock.mock(UserInstitution.class);
+        ArgumentCaptor<Document> embeddedCaptor = ArgumentCaptor.forClass(Document.class);
+        when(UserInstitution.count(embeddedCaptor.capture()))
+                .thenReturn(Uni.createFrom().item(0L));
+        UniAssertSubscriber<Boolean> subscriber = userInstitutionService
+                .checkExistsValidUserProduct(userId, null, productId, PermissionTypeEnum.ANY)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("institutionId"));
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("productId"));
+        Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("role"));
+        subscriber.assertCompleted().assertItem(false);
+    }
+
+    @Test
+    public void checkExistProductIdByRoleAdminWithoutInstitutionId() {
+        String userId = "userId";
+        String productId = "productId";
+        PanacheMock.mock(UserInstitution.class);
+        ArgumentCaptor<Document> embeddedCaptor = ArgumentCaptor.forClass(Document.class);
+        when(UserInstitution.count(embeddedCaptor.capture()))
+                .thenReturn(Uni.createFrom().item(1L));
+        UniAssertSubscriber<Boolean> subscriber = userInstitutionService
+                .checkExistsValidUserProduct(userId, null, productId, PermissionTypeEnum.ADMIN)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("institutionId"));
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("productId"));
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("role"));
+        subscriber.assertCompleted().assertItem(true);    }
+
+    @Test
+    public void checkExistProductIdByRoleAnyWithoutInstitutionId() {
+        String userId = "userId";
+        String productId = "productId";
+        PanacheMock.mock(UserInstitution.class);
+        ArgumentCaptor<Document> embeddedCaptor = ArgumentCaptor.forClass(Document.class);
+        when(UserInstitution.count(embeddedCaptor.capture()))
+                .thenReturn(Uni.createFrom().item(1L));
+        UniAssertSubscriber<Boolean> subscriber = userInstitutionService
+                .checkExistsValidUserProduct(userId, null, productId, PermissionTypeEnum.ANY)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("institutionId"));
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("productId"));
+        Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("role"));
+        subscriber.assertCompleted().assertItem(true);
+    }
+
+    @Test
+    public void checkExistsValidUserProductAdminWithInstitutionIdAndProductId() {
+        String userId = "userId";
+        String productId = "productId";
+        String institutionId = "institutionId";
+        PanacheMock.mock(UserInstitution.class);
+        ArgumentCaptor<Document> embeddedCaptor = ArgumentCaptor.forClass(Document.class);
+        when(UserInstitution.count(embeddedCaptor.capture()))
+                .thenReturn(Uni.createFrom().item(0L));
+        UniAssertSubscriber<Boolean> subscriber = userInstitutionService
+                .checkExistsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ADMIN)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("institutionId"));
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("productId"));
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("role"));
+        subscriber.assertCompleted().assertItem(false);
+    }
+
+    @Test
+    public void checkExistsValidUserProductAnyWithInstitutionIdAndProductId() {
+        String userId = "userId";
+        String productId = "productId";
+        String institutionId = "institutionId";
+        PanacheMock.mock(UserInstitution.class);
+        ArgumentCaptor<Document> embeddedCaptor = ArgumentCaptor.forClass(Document.class);
+        when(UserInstitution.count(embeddedCaptor.capture()))
+                .thenReturn(Uni.createFrom().item(0L));
+        UniAssertSubscriber<Boolean> subscriber = userInstitutionService
+                .checkExistsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ANY)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("institutionId"));
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("productId"));
+        Assertions.assertFalse(embeddedCaptor.getValue().toString().contains("role"));
+        subscriber.assertCompleted().assertItem(false);
+    }
+
+    @Test
+    public void checkExistProductIdByRoleAdminWithInstitutionIdAndProductId() {
+        String userId = "userId";
+        String productId = "productId";
+        String institutionId = "institutionId";
+        PanacheMock.mock(UserInstitution.class);
+        ArgumentCaptor<Document> embeddedCaptor = ArgumentCaptor.forClass(Document.class);
+        when(UserInstitution.count(embeddedCaptor.capture()))
+                .thenReturn(Uni.createFrom().item(1L));
+
+        UniAssertSubscriber<Boolean> subscriber = userInstitutionService
+                .checkExistsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ADMIN)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("institutionId"));
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("productId"));
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("role"));
+        subscriber.assertCompleted().assertItem(true);    }
+
+    @Test
+    public void checkExistProductIdByRoleAnyWithInstitutionIdAndProductId() {
+        String userId = "userId";
+        String productId = "productId";
+        String institutionId = "institutionId";
+        PanacheMock.mock(UserInstitution.class);
+
+        ArgumentCaptor<Document> embeddedCaptor = ArgumentCaptor.forClass(Document.class);
+        when(UserInstitution.count(embeddedCaptor.capture()))
+                .thenReturn(Uni.createFrom().item(1L));
+        UniAssertSubscriber<Boolean> subscriber = userInstitutionService
+                .checkExistsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ANY)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("institutionId"));
+        Assertions.assertTrue(embeddedCaptor.getValue().toString().contains("productId"));
+        subscriber.assertCompleted().assertItem(true);
     }
 
     @Test
@@ -97,7 +301,7 @@ class UserInstitutionServiceTest {
                 .thenReturn(query);
         when(query.page(anyInt(), anyInt())).thenReturn(query);
         when(query.stream()).thenReturn(Multi.createFrom().item(userInstitution));
-        AssertSubscriber<UserInstitution> subscriber =  userInstitutionService.paginatedFindAllWithFilter(parameterMap, 0, 100)
+        AssertSubscriber<UserInstitution> subscriber = userInstitutionService.paginatedFindAllWithFilter(parameterMap, 0, 100)
                 .subscribe().withSubscriber(AssertSubscriber.create(10));
         List<UserInstitution> response = subscriber.assertCompleted().getItems();
         Assertions.assertEquals(1, response.size());
@@ -116,7 +320,7 @@ class UserInstitutionServiceTest {
                 .thenReturn(query);
         when(query.page(anyInt(), anyInt())).thenReturn(query);
         when(query.firstResult()).thenReturn(Uni.createFrom().item(userInstitution));
-        UniAssertSubscriber<UserInstitution> subscriber =  userInstitutionService.retrieveFirstFilteredUserInstitution(parameterMap)
+        UniAssertSubscriber<UserInstitution> subscriber = userInstitutionService.retrieveFirstFilteredUserInstitution(parameterMap)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         subscriber.assertCompleted().assertItem(userInstitution);
     }
@@ -134,7 +338,7 @@ class UserInstitutionServiceTest {
         when(query.page(anyInt(), anyInt())).thenReturn(query);
         when(query.stream()).thenReturn(Multi.createFrom().item(userInstitution));
 
-        AssertSubscriber<UserInstitution> subscriber =  userInstitutionService.findAllWithFilter(parameterMap)
+        AssertSubscriber<UserInstitution> subscriber = userInstitutionService.findAllWithFilter(parameterMap)
                 .subscribe().withSubscriber(AssertSubscriber.create(10));
 
         List<UserInstitution> actual = subscriber.assertCompleted().getItems();
@@ -156,7 +360,7 @@ class UserInstitutionServiceTest {
                 .thenReturn(query);
         when(query.page(anyInt(), anyInt())).thenReturn(query);
         when(query.list()).thenReturn(Uni.createFrom().item(userInstitutionList));
-        UniAssertSubscriber<List<UserInstitution>> subscriber =  userInstitutionService.retrieveFilteredUserInstitution(parameterMap)
+        UniAssertSubscriber<List<UserInstitution>> subscriber = userInstitutionService.retrieveFilteredUserInstitution(parameterMap)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         subscriber.assertCompleted().assertItem(userInstitutionList);
     }
@@ -286,7 +490,7 @@ class UserInstitutionServiceTest {
     }
 
     @Test
-    void deleteUserInstitutionProduct(){
+    void deleteUserInstitutionProduct() {
         final String userId = "userId";
         String institutionId = "institutionId";
         PanacheMock.mock(UserInstitution.class);

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserPermissionServiceImplTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserPermissionServiceImplTest.java
@@ -36,11 +36,32 @@ public class UserPermissionServiceImplTest {
     public void testHasPermissionWithAnyPermission() {
         // Arrange
         UserInstitution userInstitution = new UserInstitution();
-        userInstitution.setProducts(Collections.emptyList());
-        Mockito.when(userInstitutionService.retrieveFirstFilteredUserInstitution(anyMap())).thenReturn(Uni.createFrom().item(userInstitution));
-
+        OnboardedProduct product = new OnboardedProduct();
+        product.setRole(PartyRole.OPERATOR);
+        product.setProductId(productId);
+        userInstitution.setProducts(Collections.singletonList(product));
+        Mockito.when(userInstitutionService.checkExistsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ANY))
+                .thenReturn(Uni.createFrom().item(true));
         // Act
         Uni<Boolean> result = userPermissionService.hasPermission(institutionId, productId, PermissionTypeEnum.ANY, userId);
+        UniAssertSubscriber<Boolean> subscriber = result.subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        // Assert
+        subscriber.assertCompleted().assertItem(true);
+    }
+
+    @Test
+    public void testHasPermissionWithADminPermissionOnlyWithProductId() {
+        // Arrange
+        UserInstitution userInstitution = new UserInstitution();
+        OnboardedProduct product = new OnboardedProduct();
+        product.setRole(PartyRole.OPERATOR);
+        product.setProductId(productId);
+        userInstitution.setProducts(Collections.singletonList(product));
+        Mockito.when(userInstitutionService.checkExistsValidUserProduct(userId, null, productId, PermissionTypeEnum.ANY))
+                .thenReturn(Uni.createFrom().item(true));
+        // Act
+        Uni<Boolean> result = userPermissionService.hasPermission(null, productId, PermissionTypeEnum.ANY, userId);
         UniAssertSubscriber<Boolean> subscriber = result.subscribe().withSubscriber(UniAssertSubscriber.create());
 
         // Assert
@@ -55,8 +76,8 @@ public class UserPermissionServiceImplTest {
         product.setRole(PartyRole.MANAGER);
         product.setProductId(productId);
         userInstitution.setProducts(Collections.singletonList(product));
-        Mockito.when(userInstitutionService.retrieveFirstFilteredUserInstitution(anyMap())).thenReturn(Uni.createFrom().item(userInstitution));
-
+        Mockito.when(userInstitutionService.checkExistsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ADMIN))
+                .thenReturn(Uni.createFrom().item(true));
         // Act
         Uni<Boolean> result = userPermissionService.hasPermission(institutionId, productId, PermissionTypeEnum.ADMIN, userId);
         UniAssertSubscriber<Boolean> subscriber = result.subscribe().withSubscriber(UniAssertSubscriber.create());
@@ -73,8 +94,8 @@ public class UserPermissionServiceImplTest {
         product.setRole(PartyRole.OPERATOR);
         product.setProductId(productId);
         userInstitution.setProducts(Collections.singletonList(product));
-        Mockito.when(userInstitutionService.retrieveFirstFilteredUserInstitution(anyMap())).thenReturn(Uni.createFrom().item(userInstitution));
-
+        Mockito.when(userInstitutionService.checkExistsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ADMIN))
+                .thenReturn(Uni.createFrom().item(false));
         // Act
         Uni<Boolean> result = userPermissionService.hasPermission(institutionId, productId, PermissionTypeEnum.ADMIN, userId);
         UniAssertSubscriber<Boolean> subscriber = result.subscribe().withSubscriber(UniAssertSubscriber.create());
@@ -86,8 +107,8 @@ public class UserPermissionServiceImplTest {
     @Test
     public void testHasPermissionWithUserNotFound() {
         // Arrange
-        Mockito.when(userInstitutionService.retrieveFirstFilteredUserInstitution(anyMap())).thenReturn(Uni.createFrom().nullItem());
-
+        Mockito.when(userInstitutionService.checkExistsValidUserProduct(eq(null), anyString(), anyString(), any(PermissionTypeEnum.class)))
+                .thenReturn(Uni.createFrom().item(false));
         // Act
         Uni<Boolean> result = userPermissionService.hasPermission(institutionId, productId, PermissionTypeEnum.ANY, userId);
         UniAssertSubscriber<Boolean> assertSubscriber = result.subscribe().withSubscriber(UniAssertSubscriber.create());

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserPermissionServiceImplTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserPermissionServiceImplTest.java
@@ -40,7 +40,7 @@ public class UserPermissionServiceImplTest {
         product.setRole(PartyRole.OPERATOR);
         product.setProductId(productId);
         userInstitution.setProducts(Collections.singletonList(product));
-        Mockito.when(userInstitutionService.checkExistsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ANY))
+        Mockito.when(userInstitutionService.existsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ANY))
                 .thenReturn(Uni.createFrom().item(true));
         // Act
         Uni<Boolean> result = userPermissionService.hasPermission(institutionId, productId, PermissionTypeEnum.ANY, userId);
@@ -58,7 +58,7 @@ public class UserPermissionServiceImplTest {
         product.setRole(PartyRole.OPERATOR);
         product.setProductId(productId);
         userInstitution.setProducts(Collections.singletonList(product));
-        Mockito.when(userInstitutionService.checkExistsValidUserProduct(userId, null, productId, PermissionTypeEnum.ANY))
+        Mockito.when(userInstitutionService.existsValidUserProduct(userId, null, productId, PermissionTypeEnum.ANY))
                 .thenReturn(Uni.createFrom().item(true));
         // Act
         Uni<Boolean> result = userPermissionService.hasPermission(null, productId, PermissionTypeEnum.ANY, userId);
@@ -76,7 +76,7 @@ public class UserPermissionServiceImplTest {
         product.setRole(PartyRole.MANAGER);
         product.setProductId(productId);
         userInstitution.setProducts(Collections.singletonList(product));
-        Mockito.when(userInstitutionService.checkExistsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ADMIN))
+        Mockito.when(userInstitutionService.existsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ADMIN))
                 .thenReturn(Uni.createFrom().item(true));
         // Act
         Uni<Boolean> result = userPermissionService.hasPermission(institutionId, productId, PermissionTypeEnum.ADMIN, userId);
@@ -94,7 +94,7 @@ public class UserPermissionServiceImplTest {
         product.setRole(PartyRole.OPERATOR);
         product.setProductId(productId);
         userInstitution.setProducts(Collections.singletonList(product));
-        Mockito.when(userInstitutionService.checkExistsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ADMIN))
+        Mockito.when(userInstitutionService.existsValidUserProduct(userId, institutionId, productId, PermissionTypeEnum.ADMIN))
                 .thenReturn(Uni.createFrom().item(false));
         // Act
         Uni<Boolean> result = userPermissionService.hasPermission(institutionId, productId, PermissionTypeEnum.ADMIN, userId);
@@ -107,7 +107,7 @@ public class UserPermissionServiceImplTest {
     @Test
     public void testHasPermissionWithUserNotFound() {
         // Arrange
-        Mockito.when(userInstitutionService.checkExistsValidUserProduct(eq(null), anyString(), anyString(), any(PermissionTypeEnum.class)))
+        Mockito.when(userInstitutionService.existsValidUserProduct(eq(null), anyString(), anyString(), any(PermissionTypeEnum.class)))
                 .thenReturn(Uni.createFrom().item(false));
         // Act
         Uni<Boolean> result = userPermissionService.hasPermission(institutionId, productId, PermissionTypeEnum.ANY, userId);


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Refactor "/authorize" API to have institutionId as optional query param instead of required pathParam
<!--- Describe your changes in detail -->

#### Motivation and Context
We need to verify the permissions even when the only parameter for the verification is the productId.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.