### PR TITLE
[SELC-5128} refactor: Enhancement in Send Event Metrics on sc-users

### DIFF
--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserNotificationServiceImpl.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserNotificationServiceImpl.java
@@ -30,6 +30,9 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static it.pagopa.selfcare.user.constant.TemplateMailConstant.*;
+import static it.pagopa.selfcare.user.model.constants.EventsMetric.EVENTS_USER_INSTITUTION_PRODUCT_FAILURE;
+import static it.pagopa.selfcare.user.model.constants.EventsMetric.EVENTS_USER_INSTITUTION_PRODUCT_SUCCESS;
+import static it.pagopa.selfcare.user.model.constants.EventsName.EVENT_USER_MS_NAME;
 
 
 @Slf4j
@@ -46,11 +49,6 @@ public class UserNotificationServiceImpl implements UserNotificationService {
     private final TelemetryClient telemetryClient;
 
 
-    private static final String EVENT_NAME = "USER-MS";
-    private static final String SEND_EVENTS_FAILURE_METRICS = "SendEvents_failures";
-    private static final String SEND_EVENTS_SUCCESS_METRICS = "SendEvents_successes";
-
-
     public UserNotificationServiceImpl(Configuration freemarkerConfig, CloudTemplateLoader cloudTemplateLoader, MailService mailService,
                                        @ConfigProperty(name = "user-ms.eventhub.users.enabled") boolean eventHubUsersEnabled, TelemetryClient telemetryClient) {
         this.mailService = mailService;
@@ -65,9 +63,9 @@ public class UserNotificationServiceImpl implements UserNotificationService {
         return eventHubUsersEnabled
                 ? eventHubRestClient.sendMessage(userNotificationToSend)
                     .onItem().invoke(() -> log.info("sent dataLake notification for id : {}", userNotificationToSend.getId()))
-                    .onItem().invoke(() -> telemetryClient.trackEvent(EVENT_NAME, Map.of(), Map.of(SEND_EVENTS_SUCCESS_METRICS, 1D)))
+                    .onItem().invoke(() -> telemetryClient.trackEvent(EVENT_USER_MS_NAME, Map.of(), Map.of(EVENTS_USER_INSTITUTION_PRODUCT_SUCCESS, 1D)))
                     .onFailure().invoke(throwable -> log.warn("error during send dataLake notification for id {}: {} ", userNotificationToSend.getId(), throwable.getMessage(), throwable))
-                    .onFailure().invoke(() -> telemetryClient.trackEvent(EVENT_NAME, Map.of(), Map.of(SEND_EVENTS_FAILURE_METRICS, 1D)))
+                    .onFailure().invoke(() -> telemetryClient.trackEvent(EVENT_USER_MS_NAME, Map.of(), Map.of(EVENTS_USER_INSTITUTION_PRODUCT_FAILURE, 1D)))
                     .replaceWith(userNotificationToSend)
                 : Uni.createFrom().item(userNotificationToSend);
     }

--- a/libs/user-sdk-model/src/main/java/it.pagopa.selfcare.user.model/constants/EventsMetric.java
+++ b/libs/user-sdk-model/src/main/java/it.pagopa.selfcare.user.model/constants/EventsMetric.java
@@ -1,0 +1,10 @@
+package it.pagopa.selfcare.user.model.constants;
+
+public class EventsMetric {
+
+
+    public static final String EVENTS_USER_INSTITUTION_FAILURE = "EventsUserInstitution_failures";
+    public static final String EVENTS_USER_INSTITUTION_SUCCESS = "EventsUserInstitution_success";
+    public static final String EVENTS_USER_INSTITUTION_PRODUCT_FAILURE = "EventsUserInstitutionProduct_failures";
+    public static final String EVENTS_USER_INSTITUTION_PRODUCT_SUCCESS = "EventsUserInstitutionProduct_success";
+}

--- a/libs/user-sdk-model/src/main/java/it.pagopa.selfcare.user.model/constants/EventsName.java
+++ b/libs/user-sdk-model/src/main/java/it.pagopa.selfcare.user.model/constants/EventsName.java
@@ -1,0 +1,7 @@
+package it.pagopa.selfcare.user.model.constants;
+
+public class EventsName {
+
+    public static final String EVENT_USER_MS_NAME = "USER-MS";
+    public static final String EVENT_USER_CDC_NAME = "USER-MS";
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

**Event Metrics Storage for UserInstitution and Individual Products**:
We have added the capability to save event metrics for UserInstitution records as well as for individual products associated with a UserInstitution. This granularity allows for a detailed understanding of how many events are being sent to the queue, enabling better monitoring and analysis.

**Centralization of Metric Names:**
Metric names have been centralized within the sdk-model. This ensures consistency and maintainability across the codebase, reducing the likelihood of discrepancies and making it easier to manage and update metric names in the future.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The primary motivation behind these changes is to provide better insights into the event flow within the system. By tracking metrics at both the UserInstitution and individual product levels, we can gain a deeper understanding of event distribution and identify any potential bottlenecks or areas for improvement. Centralizing metric names within the **sdk-model** further enhances code maintainability and clarity.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.