### PR TITLE
[SELC-5193] feat: Modify Endpoint Response for Existing ACTIVE User-Institution Association

### DIFF
--- a/apps/user-ms/src/main/docs/openapi.json
+++ b/apps/user-ms/src/main/docs/openapi.json
@@ -433,14 +433,13 @@
         },
         "responses" : {
           "200" : {
-            "description" : "OK",
+            "description" : "User created or updated!",
             "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string"
-                }
-              }
+              "application/json" : { }
             }
+          },
+          "201" : {
+            "description" : "User already has the active role for that product!"
           },
           "401" : {
             "description" : "Not Authorized"
@@ -911,10 +910,13 @@
         },
         "responses" : {
           "200" : {
-            "description" : "OK",
+            "description" : "User created or updated!",
             "content" : {
               "application/json" : { }
             }
+          },
+          "201" : {
+            "description" : "User already has the active role for that product!"
           },
           "401" : {
             "description" : "Not Authorized"

--- a/apps/user-ms/src/main/docs/openapi.yaml
+++ b/apps/user-ms/src/main/docs/openapi.yaml
@@ -304,11 +304,11 @@ paths:
               $ref: "#/components/schemas/CreateUserDto"
       responses:
         "200":
-          description: OK
+          description: User created or updated!
           content:
-            application/json:
-              schema:
-                type: string
+            application/json: {}
+        "201":
+          description: User already has the active role for that product!
         "401":
           description: Not Authorized
         "403":
@@ -636,9 +636,11 @@ paths:
               $ref: "#/components/schemas/AddUserRoleDto"
       responses:
         "200":
-          description: OK
+          description: User created or updated!
           content:
             application/json: {}
+        "201":
+          description: User already has the active role for that product!
         "401":
           description: Not Authorized
         "403":

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserService.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserService.java
@@ -14,6 +14,7 @@ import it.pagopa.selfcare.user.entity.UserInfo;
 import it.pagopa.selfcare.user.model.LoggedUser;
 import it.pagopa.selfcare.user.model.UserNotificationToSend;
 import it.pagopa.selfcare.user.model.constants.OnboardedProductState;
+import it.pagopa.selfcare.user.service.utils.CreateOrUpdateUserByFiscalCodeResponse;
 import org.openapi.quarkus.user_registry_json.model.UserResource;
 
 import java.time.LocalDateTime;
@@ -49,9 +50,9 @@ public interface UserService {
 
     Uni<Void> updateUserProductStatus(String userId, String institutionId, String productId, OnboardedProductState status, String productRole, LoggedUser loggedUser);
 
-    Uni<String> createOrUpdateUserByFiscalCode(CreateUserDto userDto, LoggedUser loggedUser);
+    Uni<CreateOrUpdateUserByFiscalCodeResponse> createOrUpdateUserByFiscalCode(CreateUserDto userDto, LoggedUser loggedUser);
 
-    Uni<Void> createOrUpdateUserByUserId(AddUserRoleDto userDto, String userId, LoggedUser loggedUser);
+    Uni<String> createOrUpdateUserByUserId(AddUserRoleDto userDto, String userId, LoggedUser loggedUser);
 
     Multi<UserDataResponse> retrieveUsersData(String institutionId, String personId, List<String> roles, List<String> states, List<String> products, List<String> productRoles, String userId);
 

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/utils/CreateOrUpdateUserByFiscalCodeResponse.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/utils/CreateOrUpdateUserByFiscalCodeResponse.java
@@ -1,0 +1,12 @@
+package it.pagopa.selfcare.user.service.utils;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CreateOrUpdateUserByFiscalCodeResponse {
+
+    private String userId;
+    private OPERATION_TYPE operationType;
+}

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/utils/OPERATION_TYPE.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/utils/OPERATION_TYPE.java
@@ -1,0 +1,5 @@
+package it.pagopa.selfcare.user.service.utils;
+
+public enum OPERATION_TYPE {
+    CREATED_OR_UPDATED,SKIPPED
+}

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/controller/UserControllerTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/controller/UserControllerTest.java
@@ -21,6 +21,7 @@ import it.pagopa.selfcare.user.model.UserNotificationToSend;
 import it.pagopa.selfcare.user.model.constants.OnboardedProductState;
 import it.pagopa.selfcare.user.service.UserRegistryService;
 import it.pagopa.selfcare.user.service.UserService;
+import it.pagopa.selfcare.user.service.utils.CreateOrUpdateUserByFiscalCodeResponse;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -532,8 +533,8 @@ class UserControllerTest {
         CreateUserDto userDto = buildCreateUserDto();
 
         // Mock the userService.createOrUpdateUser method
-        when(userService.createOrUpdateUserByFiscalCode(any(CreateUserDto.class), any(LoggedUser.class)))
-                .thenReturn(Uni.createFrom().nullItem());
+        when(userService.createOrUpdateUserByFiscalCode(any(CreateUserDto.class), any()))
+                .thenReturn(Uni.createFrom().item(CreateOrUpdateUserByFiscalCodeResponse.builder().build()));
 
         // Perform the API call
         given()
@@ -561,7 +562,7 @@ class UserControllerTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .body(userDto)
-                .post("/")
+                .post()
                 .then()
                 .statusCode(400);
     }
@@ -574,8 +575,8 @@ class UserControllerTest {
 
 
         // Mock the userService.createOrUpdateUser method
-        when(userService.createOrUpdateUserByUserId(any(AddUserRoleDto.class), anyString(), any(LoggedUser.class)))
-                .thenReturn(Uni.createFrom().nullItem());
+        when(userService.createOrUpdateUserByUserId(any(AddUserRoleDto.class), anyString(), any()))
+                .thenReturn(Uni.createFrom().item("example"));
 
         // Perform the API call
         given()
@@ -584,7 +585,7 @@ class UserControllerTest {
                 .body(userDto)
                 .post("/userId")
                 .then()
-                .statusCode(204);
+                .statusCode(201);
     }
 
     @Test

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
@@ -923,16 +923,6 @@ class UserServiceTest {
         addUserRoleProduct.setProductRoles(List.of("admin"));
         LoggedUser loggedUser = LoggedUser.builder().build();
 
-        Product product = new Product();
-        product.setDescription("description");
-
-        UserToNotify userToNotify = new UserToNotify();
-        userToNotify.setUserId(userId.toString());
-
-        UserNotificationToSend userNotificationToSend = new UserNotificationToSend();
-        userNotificationToSend.setUser(userToNotify);
-
-
         when(userRegistryApi.findByIdUsingGET(any(), eq("userId"))).thenReturn(Uni.createFrom().item(userResource));
         when(userInstitutionService.findByUserIdAndInstitutionId(userResource.getId().toString(), addUserRoleDto.getInstitutionId())).thenReturn(Uni.createFrom().item(createUserInstitution()));
 
@@ -942,7 +932,8 @@ class UserServiceTest {
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
         // Verify the result
-        subscriber.assertFailedWith(InvalidRequestException.class, "User already has roles on Product test");
+        String userId = subscriber.awaitItem().getItem();
+        assertNull(userId);
     }
 
     @Test
@@ -968,7 +959,8 @@ class UserServiceTest {
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
         // Verify the result
-        subscriber.assertFailedWith(InvalidRequestException.class);
+        String userId = subscriber.awaitItem().getItem();
+        assertNull(userId);
         verify(userRegistryApi).findByIdUsingGET(any(), eq("userId"));
     }
 

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
@@ -932,8 +932,7 @@ class UserServiceTest {
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
         // Verify the result
-        String userId = subscriber.awaitItem().getItem();
-        assertNull(userId);
+        assertNull(subscriber.awaitItem().getItem());
     }
 
     @Test
@@ -959,8 +958,7 @@ class UserServiceTest {
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
         // Verify the result
-        String userId = subscriber.awaitItem().getItem();
-        assertNull(userId);
+        assertNull(subscriber.awaitItem().getItem());
         verify(userRegistryApi).findByIdUsingGET(any(), eq("userId"));
     }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* Updated the logic in the endpoint to check if an existing association is in the ACTIVE state.
* Modified the response to return a 200 status code instead of a 400 error if the association is already ACTIVE.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This pull request modifies the behavior of the endpoint that creates a new association between a user, product, and institution. Previously, if the association already existed in an ACTIVE state, the endpoint would return a 400 error. With this change, the endpoint will now return a 200 status code in such cases, indicating that the operation was successful and the association is already in an ACTIVE state.
The previous logic caused unnecessary errors when an onboarding try to persist an user already present with a product. By returning a 200 status code, we provide a more accurate and user-friendly response, indicating that the user has already that role in ACTIVE

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.