### PR TITLE
hotfix: nullpointer when retrieve WorkContracts on retrievemail method

### DIFF
--- a/.github/workflows/swagger_detect_quarkus_ms.yml
+++ b/.github/workflows/swagger_detect_quarkus_ms.yml
@@ -1,4 +1,4 @@
-name: Swagger Detect Conflict and Update Onboarding MS
+name: Swagger Detect Conflict and Update
 on:
   pull_request:
     branches:

--- a/apps/user-group-ms/app/src/main/docs/openapi.json
+++ b/apps/user-group-ms/app/src/main/docs/openapi.json
@@ -26,7 +26,7 @@
   "paths" : {
     "/v1/user-groups" : {
       "get" : {
-        "tags" : [ "UserGroup", "external-v2", "support", "support-pnpg" ],
+        "tags" : [ "UserGroup", "external-pnpg", "external-v2", "support", "support-pnpg" ],
         "summary" : "getUserGroups",
         "description" : "Service that allows to get a list of UserGroup entities",
         "operationId" : "getUserGroupsUsingGET",

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserNotificationServiceImpl.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserNotificationServiceImpl.java
@@ -192,7 +192,9 @@ public class UserNotificationServiceImpl implements UserNotificationService {
     }
 
     private static String retrieveMail(UserResource user, UserInstitution institution) {
-        WorkContactResource certEmail = user.getWorkContacts().getOrDefault(institution.getUserMailUuid(), null);
+        WorkContactResource certEmail = Optional.ofNullable(user.getWorkContacts())
+                .map(wc -> wc.getOrDefault(institution.getUserMailUuid(), null))
+                .orElse(null);
         String email;
         if (certEmail == null || certEmail.getEmail() == null || StringUtils.isBlank(certEmail.getEmail().getValue())) {
             throw new InvalidRequestException("Missing mail for userId: " + user.getId());


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Adding verification if workContracts is not null on retrievemail method

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

It causes NullPointerExeception when user has workContracts null.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.