### PR TITLE
[SELC-5956] feat: added check of uniqueness group name in creation and editing api

### DIFF
--- a/apps/user-group-ms/connector-api/src/main/java/it/pagopa/selfcare/user_group/connector/exception/ResourceAlreadyExistsException.java
+++ b/apps/user-group-ms/connector-api/src/main/java/it/pagopa/selfcare/user_group/connector/exception/ResourceAlreadyExistsException.java
@@ -5,4 +5,8 @@ public class ResourceAlreadyExistsException extends RuntimeException {
     public ResourceAlreadyExistsException(String msg, Throwable cause) {
         super(msg, cause);
     }
+
+    public ResourceAlreadyExistsException(String msg) {
+        super(msg);
+    }
 }

--- a/apps/user-group-ms/core/src/test/java/it/pagopa/selfcare/user_group/core/UserGroupServiceImplTest.java
+++ b/apps/user-group-ms/core/src/test/java/it/pagopa/selfcare/user_group/core/UserGroupServiceImplTest.java
@@ -147,7 +147,7 @@ class UserGroupServiceImplTest {
         UserGroupOperations input = TestUtils.mockInstance(new DummyGroup(), "setId", "setCreateAt", "setModifiedAt");
         input.setName("existingGroupName");
 
-        UserGroupOperations existingGroup = TestUtils.mockInstance(new DummyGroup(), "setId", "setCreateAt", "setModifiedAt");
+        UserGroupOperations existingGroup = TestUtils.mockInstance(new DummyGroup(), "setCreateAt", "setModifiedAt");
         existingGroup.setName("existingGroupName");
         Page<UserGroupOperations> existingGroups = getPage(Collections.singletonList(existingGroup), Pageable.unpaged(), () -> 1L);
 
@@ -334,7 +334,7 @@ class UserGroupServiceImplTest {
         group.setName("existingGroupName");
 
         UserGroupOperations foundGroup = TestUtils.mockInstance(new DummyGroup());
-        foundGroup.setId("foundId");
+        foundGroup.setId(id);
         foundGroup.setName("existingGroupName");
         foundGroup.setStatus(UserGroupStatus.ACTIVE);
 
@@ -359,6 +359,8 @@ class UserGroupServiceImplTest {
                 .findById(id);
         verify(groupConnectorMock, times(1))
                 .findAll(any(), any());
+        verify(groupConnectorMock, times(1))
+                .save(any());
         verifyNoMoreInteractions(groupConnectorMock);
     }
 


### PR DESCRIPTION
#### List of Changes

added check of uniqueness group name in creation and editing api

#### Motivation and Context

To allow the existence of a group with the same name as a previously deleted group the unique index on the collection will be removed, and an application control will be added to inhibit the creation and modification of the group name if there are active or suspended groups with the same name.

#### How Has This Been Tested?

local

#### Screenshots (if appropriate):

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.