### PR TITLE
ops: added autoscale_settings vars for MongoDB db

### DIFF
--- a/infra/container_apps/user-group-ms/env/uat-pnpg/terraform.tfvars
+++ b/infra/container_apps/user-group-ms/env/uat-pnpg/terraform.tfvars
@@ -43,3 +43,7 @@ secrets_names = {
   "MONGODB_CONNECTION_URI"                = "mongodb-connection-string"
   "JWT_TOKEN_PUBLIC_KEY"                  = "jwt-public-key"
 }
+
+autoscale_settings = [{
+  max_throughput = 1000
+}]

--- a/infra/container_apps/user-group-ms/mongo_db.tf
+++ b/infra/container_apps/user-group-ms/mongo_db.tf
@@ -2,6 +2,13 @@ resource "azurerm_cosmosdb_mongo_database" "selc_user_group" {
   name                = "selcUserGroup"
   resource_group_name = local.mongo_db.mongodb_rg_name
   account_name        = local.mongo_db.cosmosdb_account_mongodb_name
+
+  dynamic "autoscale_settings" {
+    for_each = var.autoscale_settings
+    content {
+      max_throughput = autoscale_settings.value.max_throughput
+    }
+  }
 }
 
 resource "azurerm_management_lock" "mongodb_selc_user_group" {

--- a/infra/container_apps/user-group-ms/variables.tf
+++ b/infra/container_apps/user-group-ms/variables.tf
@@ -73,3 +73,11 @@ variable "suffix_increment" {
   description = "Suffix increment Container App Environment name"
   default     = ""
 }
+
+variable "autoscale_settings" {
+  type = list(object({
+    max_throughput = number
+  }))
+  description = "MongoDB autoscale settings"
+  default = []
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* Added autoscale_settings vars to infra/**/user-groups 
* Set autoscale_settings in uat-pnpg vars
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
PNPG mongodb instance has an max_throughput equals 1000 but previous infra did not support setting this value.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.