### PR TITLE
[SELC-6228] Limit number of admin-psp to 3 for prod-pagopa

### DIFF
--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/exception/NumberOfAdminsExceededException.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/exception/NumberOfAdminsExceededException.java
@@ -1,0 +1,9 @@
+package it.pagopa.selfcare.user.exception;
+
+public class NumberOfAdminsExceededException extends RuntimeException {
+
+    public NumberOfAdminsExceededException(String message) {
+        super(message);
+    }
+
+}

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionService.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionService.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.user.service;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
+import it.pagopa.selfcare.onboarding.common.ProductId;
 import it.pagopa.selfcare.user.constant.PermissionTypeEnum;
 import it.pagopa.selfcare.user.controller.request.UpdateDescriptionDto;
 import it.pagopa.selfcare.user.controller.response.UserInstitutionResponse;
@@ -22,6 +23,8 @@ public interface UserInstitutionService {
     Multi<UserInstitutionResponse> findByUserId(String userId);
 
     Multi<UserInstitution> paginatedFindAllWithFilter(Map<String, Object> queryParameter, Integer page, Integer size);
+
+    Uni<Long> countInstitutionProductRoles(String institutionId, ProductId productId, String productRole);
 
     Multi<UserInstitution> findAllWithFilter(Map<String, Object> queryParameter);
 

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionServiceDefault.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionServiceDefault.java
@@ -5,6 +5,7 @@ import io.quarkus.panache.common.Page;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
+import it.pagopa.selfcare.onboarding.common.ProductId;
 import it.pagopa.selfcare.user.constant.PermissionTypeEnum;
 import it.pagopa.selfcare.user.constant.SelfCareRole;
 import it.pagopa.selfcare.user.controller.request.UpdateDescriptionDto;
@@ -227,6 +228,23 @@ public class UserInstitutionServiceDefault implements UserInstitutionService {
         Document query = queryUtils.buildQueryDocument(filterMap, USER_INSTITUTION_COLLECTION);
 
         return runUserInstitutionCountQuery(query);
+    }
+
+    @Override
+    public Uni<Long> countInstitutionProductRoles(String institutionId, ProductId productId, String productRole) {
+        Map<String, Object> userFilter = UserInstitutionFilter.builder()
+                .institutionId(institutionId)
+                .build().constructMap();
+        Map<String, Object> productFilter = OnboardedProductFilter.builder()
+                .productId(productId.getValue())
+                .productRole(productRole)
+                .status(List.of(ACTIVE, PENDING, TOBEVALIDATED))
+                .build().constructMap();
+
+        Document query = queryUtils.buildQueryDocument(userUtils.retrieveMapForFilter(userFilter, productFilter), USER_INSTITUTION_COLLECTION);
+        log.debug("Query: {}", query);
+
+        return UserInstitution.count(query);
     }
 
     @Override

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserServiceImpl.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserServiceImpl.java
@@ -17,6 +17,7 @@ import it.pagopa.selfcare.user.entity.UserInstitution;
 import it.pagopa.selfcare.user.entity.filter.OnboardedProductFilter;
 import it.pagopa.selfcare.user.entity.filter.UserInstitutionFilter;
 import it.pagopa.selfcare.user.exception.InvalidRequestException;
+import it.pagopa.selfcare.user.exception.NumberOfAdminsExceededException;
 import it.pagopa.selfcare.user.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.user.exception.UserRoleAlreadyPresentException;
 import it.pagopa.selfcare.user.mapper.OnboardedProductMapper;
@@ -363,9 +364,9 @@ public class UserServiceImpl implements UserService {
     }
 
     private Uni<Void> checkNumberOfAdminsExceeded(String institutionId, String productId, List<String> productRoles) {
-        if (productId.equalsIgnoreCase(ProductId.PROD_PAGOPA.getValue()) && productRoles.contains("admin-psp")) {
+        if (ProductId.PROD_PAGOPA.getValue().equalsIgnoreCase(productId) && productRoles.contains("admin-psp")) {
             return userInstitutionService.countInstitutionProductRoles(institutionId, ProductId.PROD_PAGOPA, "admin-psp")
-                    .flatMap(n -> n >= 3 ? Uni.createFrom().failure(new InvalidRequestException("Maximum number of 3 admin-psp reached for prod-pagopa")) : Uni.createFrom().voidItem());
+                    .flatMap(n -> n >= 3 ? Uni.createFrom().failure(new NumberOfAdminsExceededException("Maximum number of 3 admin-psp reached for prod-pagopa")) : Uni.createFrom().voidItem());
         }
         return Uni.createFrom().voidItem();
     }


### PR DESCRIPTION
#### List of Changes

- Added function to count how many times a role has been assigned for a certain product of an institution
- Added check to createOrUpdateByFiscalCode api call to limit to 3 admin-psp with prod-pagopa
- Added new NumberOfAdminsExceededException

#### Motivation and Context

The number of admins for psp institutions must be limited to 3. This PR adds an extra check to the already planned one that will be added to the front end.

#### How Has This Been Tested?

Added new unit tests. Run local tests via api calls.

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.