### PR TITLE
[SELC-6286] feat: Added new service to get the number of admins for a certain product of an institution

### DIFF
--- a/apps/user-ms/src/main/docs/openapi.json
+++ b/apps/user-ms/src/main/docs/openapi.json
@@ -164,6 +164,50 @@
         } ]
       }
     },
+    "/institutions/{institutionId}/products/{productId}/adminCount" : {
+      "get" : {
+        "tags" : [ "Institution" ],
+        "summary" : "Get the number of admins for a certain product of an institution",
+        "description" : "Count the number of admins based on the combination of the provided institutionId and productId",
+        "operationId" : "getInstitutionProductAdminCount",
+        "parameters" : [ {
+          "name" : "institutionId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "productId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AdminCountResponse"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
     "/institutions/{institutionId}/products/{productId}/created-at" : {
       "put" : {
         "tags" : [ "Institution" ],
@@ -1377,6 +1421,21 @@
           },
           "hasToSendEmail" : {
             "type" : "boolean"
+          }
+        }
+      },
+      "AdminCountResponse" : {
+        "type" : "object",
+        "properties" : {
+          "institutionId" : {
+            "type" : "string"
+          },
+          "productId" : {
+            "type" : "string"
+          },
+          "adminCount" : {
+            "format" : "int64",
+            "type" : "integer"
           }
         }
       },

--- a/apps/user-ms/src/main/docs/openapi.yaml
+++ b/apps/user-ms/src/main/docs/openapi.yaml
@@ -118,6 +118,38 @@ paths:
           description: Not Allowed
       security:
       - SecurityScheme: []
+  /institutions/{institutionId}/products/{productId}/adminCount:
+    get:
+      tags:
+      - Institution
+      summary: Get the number of admins for a certain product of an institution
+      description: Count the number of admins based on the combination of the provided
+        institutionId and productId
+      operationId: getInstitutionProductAdminCount
+      parameters:
+      - name: institutionId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: productId
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminCountResponse"
+        "401":
+          description: Not Authorized
+        "403":
+          description: Not Allowed
+      security:
+      - SecurityScheme: []
   /institutions/{institutionId}/products/{productId}/created-at:
     put:
       tags:
@@ -987,6 +1019,16 @@ components:
           type: string
         hasToSendEmail:
           type: boolean
+    AdminCountResponse:
+      type: object
+      properties:
+        institutionId:
+          type: string
+        productId:
+          type: string
+        adminCount:
+          format: int64
+          type: integer
     CertifiableFieldResponseString:
       type: object
       properties:

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/InstitutionController.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/InstitutionController.java
@@ -4,6 +4,7 @@ import io.quarkus.security.Authenticated;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.user.controller.request.UpdateDescriptionDto;
+import it.pagopa.selfcare.user.controller.response.AdminCountResponse;
 import it.pagopa.selfcare.user.controller.response.UserInstitutionResponse;
 import it.pagopa.selfcare.user.controller.response.UserProductResponse;
 import it.pagopa.selfcare.user.service.UserService;
@@ -70,6 +71,18 @@ public class InstitutionController {
                                                         @QueryParam(value = "products") List<String> products,
                                                         @QueryParam(value = "productRoles") List<String> productRoles) {
         return userService.findAllUserInstitutions(institutionId, userId, roles, states, products, productRoles);
+    }
+
+    @Operation(
+            summary = "Get the number of admins for a certain product of an institution",
+            description = "Count the number of admins based on the combination of the provided institutionId and productId"
+    )
+    @GET
+    @Path(value = "/{institutionId}/products/{productId}/adminCount")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Uni<AdminCountResponse> getInstitutionProductAdminCount(@PathParam(value = "institutionId") String institutionId,
+                                                                   @PathParam(value = "productId") String productId) {
+        return userService.getInstitutionProductAdminCount(institutionId, productId);
     }
 
     @Operation(

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/response/AdminCountResponse.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/response/AdminCountResponse.java
@@ -1,0 +1,16 @@
+package it.pagopa.selfcare.user.controller.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdminCountResponse {
+
+    private String institutionId;
+    private String productId;
+    private Long adminCount;
+
+}

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionService.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionService.java
@@ -49,4 +49,6 @@ public interface UserInstitutionService {
 
     Uni<Long> updateInstitutionDescription(String institutionId, UpdateDescriptionDto updateDescriptionDto);
 
+    Uni<Long> countInstitutionProductAdmins(String institutionId, String productId);
+
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionServiceDefault.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionServiceDefault.java
@@ -261,4 +261,22 @@ public class UserInstitutionServiceDefault implements UserInstitutionService {
         Uni<Long> count = UserInstitution.count(query);
         return count.onItem().transform(c -> c > 0);
     }
+
+    @Override
+    public Uni<Long> countInstitutionProductAdmins(String institutionId, String productId) {
+        final Map<String, Object> userFilter = UserInstitutionFilter.builder()
+                .institutionId(institutionId)
+                .build().constructMap();
+        final Map<String, Object> productFilter = OnboardedProductFilter.builder()
+                .productId(productId)
+                .role(SelfCareRole.fromSelfCareAuthority(PermissionTypeEnum.ADMIN.name()))
+                .status(List.of(ACTIVE, PENDING, TOBEVALIDATED))
+                .build().constructMap();
+
+        final Document query = queryUtils.buildQueryDocument(userUtils.retrieveMapForFilter(userFilter, productFilter), USER_INSTITUTION_COLLECTION);
+        log.debug("Query: {}", query);
+
+        return UserInstitution.count(query);
+    }
+
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserService.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserService.java
@@ -59,4 +59,6 @@ public interface UserService {
     Uni<Void> sendEventsByDateAndUserIdAndInstitutionId(OffsetDateTime fromDate, String institutionId, String userId);
 
     Uni<UserInstitutionWithActions> getUserInstitutionWithPermission(String userId, String institutionId, String productId);
+
+    Uni<AdminCountResponse> getInstitutionProductAdminCount(String institutionId, String productId);
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserServiceImpl.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserServiceImpl.java
@@ -813,4 +813,10 @@ public class UserServiceImpl implements UserService {
                 .toList();
     }
 
+    @Override
+    public Uni<AdminCountResponse> getInstitutionProductAdminCount(String institutionId, String productId) {
+        return userInstitutionService.countInstitutionProductAdmins(institutionId, productId)
+                .onItem().transform(adminCount -> new AdminCountResponse(institutionId, productId, adminCount));
+    }
+
 }

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/controller/InstitutionControllerTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/controller/InstitutionControllerTest.java
@@ -8,6 +8,7 @@ import io.restassured.http.ContentType;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.user.controller.request.UpdateDescriptionDto;
+import it.pagopa.selfcare.user.controller.response.AdminCountResponse;
 import it.pagopa.selfcare.user.controller.response.UserInstitutionResponse;
 import it.pagopa.selfcare.user.controller.response.UserProductResponse;
 import it.pagopa.selfcare.user.exception.ResourceNotFoundException;
@@ -202,6 +203,40 @@ class InstitutionControllerTest {
                 .body(updateDescriptionDto)
                 .pathParam("institutionId", institutionId)
                 .put("/{institutionId}")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    @TestSecurity(user = "userJwt")
+    void getInstitutionProductAdminCount() {
+        final String institutionId = "institutionId";
+        final String productId = "productId";
+
+        Mockito.when(userService.getInstitutionProductAdminCount(institutionId, productId))
+                .thenReturn(Uni.createFrom().item(new AdminCountResponse(institutionId, productId, 2L)));
+
+        given()
+                .when()
+                .contentType(ContentType.JSON)
+                .pathParam("institutionId", institutionId)
+                .pathParam("productId", productId)
+                .get("/{institutionId}/products/{productId}/adminCount")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void getInstitutionProductAdminCount_NotAuthorized() {
+        final String institutionId = "institutionId";
+        final String productId = "productId";
+
+        given()
+                .when()
+                .contentType(ContentType.JSON)
+                .pathParam("institutionId", institutionId)
+                .pathParam("productId", productId)
+                .get("/{institutionId}/products/{productId}/adminCount")
                 .then()
                 .statusCode(401);
     }

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserInstitutionServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserInstitutionServiceTest.java
@@ -647,6 +647,27 @@ class UserInstitutionServiceTest {
         subscriber.assertCompleted().assertItem(1L);
     }
 
+    @Test
+    void countInstitutionProductAdmins() {
+        final String institutionId = "institutionId";
+        final String productId = "productId";
+        PanacheMock.mock(UserInstitution.class);
+        ArgumentCaptor<Document> embeddedCaptor = ArgumentCaptor.forClass(Document.class);
+        when(UserInstitution.count(embeddedCaptor.capture()))
+                .thenReturn(Uni.createFrom().item(2L));
+        UniAssertSubscriber<Long> subscriber = userInstitutionService
+                .countInstitutionProductAdmins(institutionId, productId)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        final String docString = embeddedCaptor.getValue().toString();
+        Assertions.assertTrue(docString.contains("institutionId"));
+        Assertions.assertTrue(docString.contains("productId"));
+        Assertions.assertTrue(docString.contains("role"));
+        Assertions.assertTrue(docString.contains("status"));
+        Assertions.assertFalse(docString.contains("userId"));
+        Assertions.assertFalse(docString.contains("productRole"));
+        subscriber.assertCompleted().assertItem(2L);
+    }
+
     private UserInstitution createDummyUserInstitution() {
         UserInstitution userInstitution = new UserInstitution();
         userInstitution.setId(ObjectId.get());

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
@@ -27,8 +27,8 @@ import it.pagopa.selfcare.user.entity.UserInstitutionRole;
 import it.pagopa.selfcare.user.entity.filter.OnboardedProductFilter;
 import it.pagopa.selfcare.user.entity.filter.UserInstitutionFilter;
 import it.pagopa.selfcare.user.exception.InvalidRequestException;
-import it.pagopa.selfcare.user.exception.UserRoleAlreadyPresentException;
 import it.pagopa.selfcare.user.exception.ResourceNotFoundException;
+import it.pagopa.selfcare.user.exception.UserRoleAlreadyPresentException;
 import it.pagopa.selfcare.user.mapper.UserMapper;
 import it.pagopa.selfcare.user.model.LoggedUser;
 import it.pagopa.selfcare.user.model.OnboardedProduct;
@@ -48,13 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.Spy;
-import org.openapi.quarkus.user_registry_json.model.BirthDateCertifiableSchema;
-import org.openapi.quarkus.user_registry_json.model.EmailCertifiableSchema;
-import org.openapi.quarkus.user_registry_json.model.FamilyNameCertifiableSchema;
-import org.openapi.quarkus.user_registry_json.model.NameCertifiableSchema;
-import org.openapi.quarkus.user_registry_json.model.UserResource;
-import org.openapi.quarkus.user_registry_json.model.UserSearchDto;
-import org.openapi.quarkus.user_registry_json.model.WorkContactResource;
+import org.openapi.quarkus.user_registry_json.model.*;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -1853,4 +1847,21 @@ class UserServiceTest {
         verify(userInstitutionService).retrieveFirstFilteredUserInstitution(queryParameter);
 
     }
+
+    @Test
+    void testGetInstitutionProductAdminCount() {
+        final String institutionId = "institutionId";
+        final String productId = "productId";
+
+        when(userInstitutionService.countInstitutionProductAdmins(institutionId, productId))
+                .thenReturn(Uni.createFrom().item(2L));
+
+        userService.getInstitutionProductAdminCount(institutionId, productId).subscribe()
+                .withSubscriber(UniAssertSubscriber.create())
+                .assertItem(new AdminCountResponse("institutionId", "productId", 2L))
+                .assertCompleted();
+
+        verify(userInstitutionService).countInstitutionProductAdmins(institutionId, productId);
+    }
+
 }


### PR DESCRIPTION
#### List of Changes

- Added function to count how many admins are assigned for a certain product of an institution
- Added new GET endpoint /{institutionId}/products/{productId}/adminCount

#### Motivation and Context

The number of admins for psp institutions must be limited to a fixed number. This PR adds a new API that will be used by dashboard and onboarding BFF to implement the check.

#### How Has This Been Tested?

- Added new unit tests
- Executed local tests

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.