### PR TITLE
[SELC-6726] Created new deleteUserInstitutionProductUsers API

### DIFF
--- a/apps/user-ms/src/main/docs/openapi.json
+++ b/apps/user-ms/src/main/docs/openapi.json
@@ -243,8 +243,15 @@
           }
         } ],
         "responses" : {
-          "204" : {
-            "description" : "No Content"
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/DeletedUserCountResponse"
+                }
+              }
+            }
           },
           "400" : {
             "description" : "Bad Request",
@@ -1550,6 +1557,21 @@
           },
           "hasToSendEmail" : {
             "type" : "boolean"
+          }
+        }
+      },
+      "DeletedUserCountResponse" : {
+        "type" : "object",
+        "properties" : {
+          "institutionId" : {
+            "type" : "string"
+          },
+          "productId" : {
+            "type" : "string"
+          },
+          "deletedUserCount" : {
+            "format" : "int64",
+            "type" : "integer"
           }
         }
       },

--- a/apps/user-ms/src/main/docs/openapi.json
+++ b/apps/user-ms/src/main/docs/openapi.json
@@ -221,6 +221,77 @@
         } ]
       }
     },
+    "/institutions/{institutionId}/products/{productId}/users" : {
+      "delete" : {
+        "tags" : [ "Institution" ],
+        "summary" : "Logically delete all the users associated with a product of an institution",
+        "description" : "Set the status of all the users associated with a product of an institution to DELETED",
+        "operationId" : "deleteUserInstitutionProductUsers",
+        "parameters" : [ {
+          "name" : "institutionId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "productId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Not Authorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
     "/institutions/{institutionId}/products/{productId}/users/count" : {
       "get" : {
         "tags" : [ "Institution" ],

--- a/apps/user-ms/src/main/docs/openapi.yaml
+++ b/apps/user-ms/src/main/docs/openapi.yaml
@@ -162,6 +162,54 @@ paths:
           description: Not Allowed
       security:
       - SecurityScheme: []
+  /institutions/{institutionId}/products/{productId}/users:
+    delete:
+      tags:
+      - Institution
+      summary: Logically delete all the users associated with a product of an institution
+      description: Set the status of all the users associated with a product of an
+        institution to DELETED
+      operationId: deleteUserInstitutionProductUsers
+      parameters:
+      - name: institutionId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: productId
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "401":
+          description: Not Authorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "404":
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+      security:
+      - SecurityScheme: []
   /institutions/{institutionId}/products/{productId}/users/count:
     get:
       tags:

--- a/apps/user-ms/src/main/docs/openapi.yaml
+++ b/apps/user-ms/src/main/docs/openapi.yaml
@@ -182,8 +182,12 @@ paths:
         schema:
           type: string
       responses:
-        "204":
-          description: No Content
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeletedUserCountResponse"
         "400":
           description: Bad Request
           content:
@@ -1113,6 +1117,16 @@ components:
           type: string
         hasToSendEmail:
           type: boolean
+    DeletedUserCountResponse:
+      type: object
+      properties:
+        institutionId:
+          type: string
+        productId:
+          type: string
+        deletedUserCount:
+          format: int64
+          type: integer
     Env:
       enum:
       - ROOT

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/constant/CustomError.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/constant/CustomError.java
@@ -5,8 +5,7 @@ public enum CustomError {
     USER_INSTITUTION_NOT_FOUND_ERROR("0031", "User having userId [%s] and institutionId [%s] not found"),
     STATUS_IS_MANDATORY("0000", "STATUS IS MANDATORY"),
     USER_TO_UPDATE_NOT_FOUND("0000", "USER TO UPDATE NOT FOUND"),
-    USERS_TO_UPDATE_NOT_FOUND("0000", "USERS TO UPDATE NOT FOUND"),
-    USERS_TO_DELETE_NOT_FOUND("0000", "USERS TO DELETE NOT FOUND");
+    USERS_TO_UPDATE_NOT_FOUND("0000", "USERS TO UPDATE NOT FOUND");
 
     private final String code;
     private final String detail;

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/constant/CustomError.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/constant/CustomError.java
@@ -5,7 +5,8 @@ public enum CustomError {
     USER_INSTITUTION_NOT_FOUND_ERROR("0031", "User having userId [%s] and institutionId [%s] not found"),
     STATUS_IS_MANDATORY("0000", "STATUS IS MANDATORY"),
     USER_TO_UPDATE_NOT_FOUND("0000", "USER TO UPDATE NOT FOUND"),
-    USERS_TO_UPDATE_NOT_FOUND("0000", "USERS TO UPDATE NOT FOUND");
+    USERS_TO_UPDATE_NOT_FOUND("0000", "USERS TO UPDATE NOT FOUND"),
+    USERS_TO_DELETE_NOT_FOUND("0000", "USERS TO DELETE NOT FOUND");
 
     private final String code;
     private final String detail;

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/InstitutionController.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/InstitutionController.java
@@ -123,4 +123,25 @@ public class InstitutionController {
                         .status(HttpStatus.SC_NO_CONTENT)
                         .build());
     }
+
+    @Operation(
+            summary = "Logically delete all the users associated with a product of an institution",
+            description = "Set the status of all the users associated with a product of an institution to DELETED"
+    )
+    @APIResponses(value = {
+            @APIResponse(responseCode = "204", description = "No Content"),
+            @APIResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = Problem.class), mediaType = "application/problem+json")),
+            @APIResponse(responseCode = "401", description = "Not Authorized", content = @Content(schema = @Schema(implementation = Problem.class), mediaType = "application/problem+json")),
+            @APIResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = Problem.class), mediaType = "application/problem+json")),
+            @APIResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = Problem.class), mediaType = "application/problem+json"))
+    })
+    @DELETE
+    @Path(value = "/{institutionId}/products/{productId}/users")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Uni<Response> deleteUserInstitutionProductUsers(@PathParam(value = "institutionId") String institutionId,
+                                                           @PathParam(value = "productId") String productId) {
+        return userService.deleteUserInstitutionProductUsers(institutionId, productId)
+                .map(ignore -> Response.status(HttpStatus.SC_NO_CONTENT).build());
+    }
+
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/InstitutionController.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/InstitutionController.java
@@ -140,7 +140,8 @@ public class InstitutionController {
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<Response> deleteUserInstitutionProductUsers(@PathParam(value = "institutionId") String institutionId,
                                                            @PathParam(value = "productId") String productId) {
-        return userService.deleteUserInstitutionProductUsers(institutionId, productId)
+        return userService.deleteUserInstitutionProductUsers(institutionId.replaceAll("[^a-zA-Z0-9-_]", ""),
+                        productId.replaceAll("[^a-zA-Z0-9-_]", ""))
                 .map(ignore -> Response.status(HttpStatus.SC_NO_CONTENT).build());
     }
 

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/InstitutionController.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/InstitutionController.java
@@ -5,6 +5,7 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
 import it.pagopa.selfcare.user.controller.request.UpdateDescriptionDto;
+import it.pagopa.selfcare.user.controller.response.DeletedUserCountResponse;
 import it.pagopa.selfcare.user.controller.response.UserInstitutionResponse;
 import it.pagopa.selfcare.user.controller.response.UserProductResponse;
 import it.pagopa.selfcare.user.controller.response.UsersCountResponse;
@@ -129,7 +130,7 @@ public class InstitutionController {
             description = "Set the status of all the users associated with a product of an institution to DELETED"
     )
     @APIResponses(value = {
-            @APIResponse(responseCode = "204", description = "No Content"),
+            @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = DeletedUserCountResponse.class), mediaType = "application/json")),
             @APIResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = Problem.class), mediaType = "application/problem+json")),
             @APIResponse(responseCode = "401", description = "Not Authorized", content = @Content(schema = @Schema(implementation = Problem.class), mediaType = "application/problem+json")),
             @APIResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = Problem.class), mediaType = "application/problem+json")),
@@ -138,11 +139,10 @@ public class InstitutionController {
     @DELETE
     @Path(value = "/{institutionId}/products/{productId}/users")
     @Produces(MediaType.APPLICATION_JSON)
-    public Uni<Response> deleteUserInstitutionProductUsers(@PathParam(value = "institutionId") String institutionId,
-                                                           @PathParam(value = "productId") String productId) {
+    public Uni<DeletedUserCountResponse> deleteUserInstitutionProductUsers(@PathParam(value = "institutionId") String institutionId,
+                                                                           @PathParam(value = "productId") String productId) {
         return userService.deleteUserInstitutionProductUsers(institutionId.replaceAll("[^a-zA-Z0-9-_]", ""),
-                        productId.replaceAll("[^a-zA-Z0-9-_]", ""))
-                .map(ignore -> Response.status(HttpStatus.SC_NO_CONTENT).build());
+                        productId.replaceAll("[^a-zA-Z0-9-_]", ""));
     }
 
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/response/DeletedUserCountResponse.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/controller/response/DeletedUserCountResponse.java
@@ -1,0 +1,14 @@
+package it.pagopa.selfcare.user.controller.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class DeletedUserCountResponse {
+
+    private String institutionId;
+    private String productId;
+    private Long deletedUserCount;
+
+}

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionService.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserInstitutionService.java
@@ -51,4 +51,6 @@ public interface UserInstitutionService {
 
     Uni<Long> countUsers(String institutionId, String productId, List<PartyRole> roles, List<OnboardedProductState> status);
 
+    Uni<Long> deleteUserInstitutionProductUsers(String institutionId, String productId);
+
 }

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserService.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserService.java
@@ -34,6 +34,8 @@ public interface UserService {
 
     Uni<Void> deleteUserInstitutionProduct(String userId, String institutionId, String productId);
 
+    Uni<Void> deleteUserInstitutionProductUsers(String institutionId, String productId);
+
     Uni<List<UserNotificationToSend>> findPaginatedUserNotificationToSend(Integer size, Integer page, String productId);
 
     Uni<List<UserInstitutionResponse>> findAllByIds(List<String> userIds);

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserService.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserService.java
@@ -34,7 +34,7 @@ public interface UserService {
 
     Uni<Void> deleteUserInstitutionProduct(String userId, String institutionId, String productId);
 
-    Uni<Void> deleteUserInstitutionProductUsers(String institutionId, String productId);
+    Uni<DeletedUserCountResponse> deleteUserInstitutionProductUsers(String institutionId, String productId);
 
     Uni<List<UserNotificationToSend>> findPaginatedUserNotificationToSend(Integer size, Integer page, String productId);
 

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserServiceImpl.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserServiceImpl.java
@@ -205,15 +205,10 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public Uni<Void> deleteUserInstitutionProductUsers(String institutionId, String productId) {
+    public Uni<DeletedUserCountResponse> deleteUserInstitutionProductUsers(String institutionId, String productId) {
         return userInstitutionService.deleteUserInstitutionProductUsers(institutionId, productId)
                 .onItem().invoke(modCount -> log.info("Updated {} userInstitution documents with institutionId {} and productId {} to status DELETED", modCount, institutionId, productId))
-                .onItem().transformToUni(modCount -> {
-                    if (modCount < 1) {
-                        return Uni.createFrom().failure(new ResourceNotFoundException(USERS_TO_DELETE_NOT_FOUND.getMessage()));
-                    }
-                    return Uni.createFrom().voidItem();
-                });
+                .onItem().transformToUni(modCount -> Uni.createFrom().item(new DeletedUserCountResponse(institutionId, productId, modCount)));
     }
 
     @Override

--- a/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserServiceImpl.java
+++ b/apps/user-ms/src/main/java/it/pagopa/selfcare/user/service/UserServiceImpl.java
@@ -205,6 +205,18 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    public Uni<Void> deleteUserInstitutionProductUsers(String institutionId, String productId) {
+        return userInstitutionService.deleteUserInstitutionProductUsers(institutionId, productId)
+                .onItem().invoke(modCount -> log.info("Updated {} userInstitution documents with institutionId {} and productId {} to status DELETED", modCount, institutionId, productId))
+                .onItem().transformToUni(modCount -> {
+                    if (modCount < 1) {
+                        return Uni.createFrom().failure(new ResourceNotFoundException(USERS_TO_DELETE_NOT_FOUND.getMessage()));
+                    }
+                    return Uni.createFrom().voidItem();
+                });
+    }
+
+    @Override
     public Uni<List<UserInstitutionResponse>> findAllByIds(List<String> userIds) {
         var userInstitutionFilters = UserInstitutionFilter.builder().userId(formatQueryParameterList(userIds)).build().constructMap();
         return userInstitutionService.findAllWithFilter(userUtils.retrieveMapForFilter(userInstitutionFilters))

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/controller/InstitutionControllerTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/controller/InstitutionControllerTest.java
@@ -9,6 +9,7 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
 import it.pagopa.selfcare.user.controller.request.UpdateDescriptionDto;
+import it.pagopa.selfcare.user.controller.response.DeletedUserCountResponse;
 import it.pagopa.selfcare.user.controller.response.UserInstitutionResponse;
 import it.pagopa.selfcare.user.controller.response.UserProductResponse;
 import it.pagopa.selfcare.user.controller.response.UsersCountResponse;
@@ -258,7 +259,7 @@ class InstitutionControllerTest {
         final String productId = "productId";
 
         Mockito.when(userService.deleteUserInstitutionProductUsers(institutionId, productId))
-                .thenReturn(Uni.createFrom().voidItem());
+                .thenReturn(Uni.createFrom().item(new DeletedUserCountResponse(institutionId, productId, 1L)));
 
         given()
                 .when()
@@ -267,7 +268,7 @@ class InstitutionControllerTest {
                 .pathParam("productId", productId)
                 .delete("/{institutionId}/products/{productId}/users")
                 .then()
-                .statusCode(204);
+                .statusCode(200);
     }
 
     @Test

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/controller/InstitutionControllerTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/controller/InstitutionControllerTest.java
@@ -251,4 +251,38 @@ class InstitutionControllerTest {
                 .statusCode(401);
     }
 
+    @Test
+    @TestSecurity(user = "userJwt")
+    void deleteUserInstitutionProductUsers() {
+        final String institutionId = "institutionId";
+        final String productId = "productId";
+
+        Mockito.when(userService.deleteUserInstitutionProductUsers(institutionId, productId))
+                .thenReturn(Uni.createFrom().voidItem());
+
+        given()
+                .when()
+                .contentType(ContentType.JSON)
+                .pathParam("institutionId", institutionId)
+                .pathParam("productId", productId)
+                .delete("/{institutionId}/products/{productId}/users")
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
+    void deleteUserInstitutionProductUsers_NotAuthorized() {
+        final String institutionId = "institutionId";
+        final String productId = "productId";
+
+        given()
+                .when()
+                .contentType(ContentType.JSON)
+                .pathParam("institutionId", institutionId)
+                .pathParam("productId", productId)
+                .delete("/{institutionId}/products/{productId}/users")
+                .then()
+                .statusCode(401);
+    }
+
 }

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserInstitutionServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserInstitutionServiceTest.java
@@ -1,7 +1,10 @@
 package it.pagopa.selfcare.user.service;
 
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.result.UpdateResult;
 import io.quarkus.mongodb.panache.common.reactive.ReactivePanacheUpdate;
 import io.quarkus.mongodb.panache.reactive.ReactivePanacheQuery;
+import io.quarkus.mongodb.reactive.ReactiveMongoCollection;
 import io.quarkus.panache.mock.PanacheMock;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -565,6 +568,24 @@ class UserInstitutionServiceTest {
                 .thenReturn(update);
         when(update.where(any())).thenReturn(Uni.createFrom().item(1L));
         UniAssertSubscriber<Long> subscriber = userInstitutionService.deleteUserInstitutionProduct(userId, institutionId, "productID")
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.assertCompleted().assertItem(1L);
+    }
+
+    @Test
+    void deleteUserInstitutionProductUsers() {
+        final String institutionId = "institutionId";
+        final String productId = "productId";
+        PanacheMock.mock(UserInstitution.class);
+
+        final UpdateResult updateResult = Mockito.mock(UpdateResult.class);
+        when(updateResult.getModifiedCount()).thenReturn(1L);
+
+        final ReactiveMongoCollection mongoCollection = Mockito.mock(ReactiveMongoCollection.class);
+        when(mongoCollection.updateMany(any(Document.class), any(Document.class), any(UpdateOptions.class))).thenReturn(Uni.createFrom().item(updateResult));
+        when(UserInstitution.mongoCollection()).thenReturn(mongoCollection);
+
+        UniAssertSubscriber<Long> subscriber = userInstitutionService.deleteUserInstitutionProductUsers(institutionId, productId)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         subscriber.assertCompleted().assertItem(1L);
     }

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
@@ -630,23 +630,23 @@ class UserServiceTest {
         final String institutionId = "institutionId";
         final String productId = "productId";
         when(userInstitutionService.deleteUserInstitutionProductUsers(institutionId, productId)).thenReturn(Uni.createFrom().item(1L));
-        UniAssertSubscriber<Void> subscriber = userService
+        UniAssertSubscriber<DeletedUserCountResponse> subscriber = userService
                 .deleteUserInstitutionProductUsers(institutionId, productId)
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
-        subscriber.assertCompleted();
+        subscriber.assertCompleted().assertItem(new DeletedUserCountResponse(institutionId, productId, 1L));
     }
 
     @Test
-    void deleteUserInstitutionProductUsersNotFound() {
+    void deleteUserInstitutionProductUsersFail() {
         final String institutionId = "institutionId";
         final String productId = "productId";
-        when(userInstitutionService.deleteUserInstitutionProductUsers(institutionId, productId)).thenReturn(Uni.createFrom().item(0L));
-        UniAssertSubscriber<Void> subscriber = userService
+        when(userInstitutionService.deleteUserInstitutionProductUsers(institutionId, productId)).thenReturn(Uni.createFrom().failure(new RuntimeException()));
+        UniAssertSubscriber<DeletedUserCountResponse> subscriber = userService
                 .deleteUserInstitutionProductUsers(institutionId, productId)
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
-        subscriber.assertFailedWith(ResourceNotFoundException.class, USERS_TO_DELETE_NOT_FOUND.getMessage());
+        subscriber.assertFailedWith(RuntimeException.class);
     }
 
     @Test

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
@@ -626,6 +626,30 @@ class UserServiceTest {
     }
 
     @Test
+    void deleteUserInstitutionProductUsers() {
+        final String institutionId = "institutionId";
+        final String productId = "productId";
+        when(userInstitutionService.deleteUserInstitutionProductUsers(institutionId, productId)).thenReturn(Uni.createFrom().item(1L));
+        UniAssertSubscriber<Void> subscriber = userService
+                .deleteUserInstitutionProductUsers(institutionId, productId)
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create());
+        subscriber.assertCompleted();
+    }
+
+    @Test
+    void deleteUserInstitutionProductUsersNotFound() {
+        final String institutionId = "institutionId";
+        final String productId = "productId";
+        when(userInstitutionService.deleteUserInstitutionProductUsers(institutionId, productId)).thenReturn(Uni.createFrom().item(0L));
+        UniAssertSubscriber<Void> subscriber = userService
+                .deleteUserInstitutionProductUsers(institutionId, productId)
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create());
+        subscriber.assertFailedWith(ResourceNotFoundException.class, USERS_TO_DELETE_NOT_FOUND.getMessage());
+    }
+
+    @Test
     void findAllByIds() {
         //given
         List<String> userIds = List.of("userId");


### PR DESCRIPTION
#### List of Changes

- Added new DELETE api /institutions/{institutionId}/products/{productId}/users to delete all the users in status ACTIVE or SUSPENDED associated to a product of an institution

#### Motivation and Context

The new api allow to delete all users related to no longer active onboardings

#### How Has This Been Tested?

- Local tests
- Unit tests

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.