### PR TITLE
[SELC-7216] Allowing to manually start integration test workflow. Upload of the cucumber test report

### DIFF
--- a/.github/workflows/integration_tests_ms.yml
+++ b/.github/workflows/integration_tests_ms.yml
@@ -39,10 +39,12 @@ jobs:
           servers: '[{"id": "selfcare-onboarding", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"id": "selfcare", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}]'
 
       - name: Run Integration Tests
+        id: int_tests
         run: mvn --projects :user-ms --also-make test -Dtest=CucumberSuite -Dsurefire.failIfNoSpecifiedTests=false
         shell: bash
 
       - name: Upload Test Results
+        if: always() && (steps.int_tests.conclusion == 'success' || steps.int_tests.conclusion == 'failure')
         uses: actions/upload-artifact@v4
         with:
           name: cucumber-report

--- a/.github/workflows/integration_tests_user_group_ms.yml
+++ b/.github/workflows/integration_tests_user_group_ms.yml
@@ -37,10 +37,12 @@ jobs:
           servers: '[{"id": "selfcare-onboarding", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"id": "selfcare", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}]'
 
       - name: Run Integration Tests
+        id: int_tests
         run: mvn --projects :user-group-ms --also-make test -Dtest=CucumberSuite -Dsurefire.failIfNoSpecifiedTests=false
         shell: bash
 
       - name: Upload Test Results
+        if: always() && (steps.int_tests.conclusion == 'success' || steps.int_tests.conclusion == 'failure')
         uses: actions/upload-artifact@v4
         with:
           name: cucumber-report

--- a/.github/workflows/integration_tests_user_group_ms.yml
+++ b/.github/workflows/integration_tests_user_group_ms.yml
@@ -11,6 +11,7 @@ on:
       - releases/*
     paths:
       - "apps/user-group-ms/**"
+  workflow_dispatch:
 
 jobs:
   integration_tests_ms:
@@ -38,3 +39,9 @@ jobs:
       - name: Run Integration Tests
         run: mvn --projects :user-group-ms --also-make test -Dtest=CucumberSuite -Dsurefire.failIfNoSpecifiedTests=false
         shell: bash
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: cucumber-report
+          path: apps/user-group-ms/target/cucumber-report/cucumber.html

--- a/apps/user-group-ms/src/test/java/it/pagopa/selfcare/user_group/integration_test/CucumberSuite.java
+++ b/apps/user-group-ms/src/test/java/it/pagopa/selfcare/user_group/integration_test/CucumberSuite.java
@@ -19,7 +19,11 @@ import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
 @Suite
 @IncludeEngines("cucumber")
 @SelectClasspathResource("features")
-@ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty")
+@ConfigurationParameters({
+    @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+    @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "html:target/cucumber-report/cucumber.html")
+})
+
 @CucumberContextConfiguration
 @SpringBootTest(classes = {SelfCareUserGroupApplication.class}, webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @TestPropertySource(locations = "classpath:application-test.properties")


### PR DESCRIPTION
#### List of Changes

- Added workflow_dispatch
- Upload of cucumber.html test report
- Upload of report even if integration tests fail

#### Motivation and Context

Allows to start the integration tests manually and see the test results in a visually friendly output.

#### How Has This Been Tested?

- Github Action Test

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.