### PR TITLE
[SELC-7474] Removed ManageProductUsers and ListProductUsers actions from ADMIN_EA role for prod-io

### DIFF
--- a/apps/user-ms/src/main/resources/role_action_mapping.json
+++ b/apps/user-ms/src/main/resources/role_action_mapping.json
@@ -820,8 +820,6 @@
       "Selc:AccessProductBackoffice",
       "Selc:ViewManagedInstitutions",
       "Selc:ViewDelegations",
-      "Selc:ManageProductUsers",
-      "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
@@ -2152,8 +2152,6 @@ class UserServiceTest {
                 "Selc:AccessProductBackoffice",
                 "Selc:ViewManagedInstitutions",
                 "Selc:ViewDelegations",
-                "Selc:ManageProductUsers",
-                "Selc:ListProductUsers",
                 "Selc:ManageProductGroups",
                 "Selc:CreateDelegation",
                 "Selc:ViewInstitutionData",

--- a/apps/user-ms/src/test/resources/features/user.feature
+++ b/apps/user-ms/src/test/resources/features/user.feature
@@ -4759,8 +4759,6 @@ Feature: User
       | Selc:AccessProductBackoffice      |
       | Selc:ViewManagedInstitutions      |
       | Selc:ViewDelegations              |
-      | Selc:ManageProductUsers           |
-      | Selc:ListProductUsers             |
       | Selc:ManageProductGroups          |
       | Selc:CreateDelegation             |
       | Selc:ViewInstitutionData          |


### PR DESCRIPTION
#### List of Changes

- Removed ManageProductUsers and ListProductUsers from ADMIN_EA role for prod-io
- Updated unit and integration tests

#### Motivation and Context

Users with ADMIN_EA role for prod-io do not have to list and manage users

#### How Has This Been Tested?

- Local tests
- Unit tests
- Integration tests

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.