### PR TITLE
[SELC-7480] Added new action ListProductGroups. Removed action ManageProductGroups from ADMIN_EA role for prod-io

### DIFF
--- a/apps/user-ms/src/main/resources/role_action_mapping.json
+++ b/apps/user-ms/src/main/resources/role_action_mapping.json
@@ -12,6 +12,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
@@ -28,6 +29,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
@@ -44,6 +46,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
@@ -60,6 +63,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
@@ -76,6 +80,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -92,6 +97,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -108,6 +114,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -124,6 +131,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -140,6 +148,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -156,6 +165,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -172,6 +182,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -188,6 +199,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -204,6 +216,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -220,6 +233,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -235,6 +249,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
@@ -250,6 +265,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
@@ -266,6 +282,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData"
     ]
@@ -283,6 +300,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
@@ -299,6 +317,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
@@ -315,6 +334,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
@@ -331,6 +351,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
@@ -347,6 +368,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -363,6 +385,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -379,6 +402,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -395,6 +419,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -411,6 +436,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -427,6 +453,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -443,6 +470,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -459,6 +487,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -475,6 +504,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -491,6 +521,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -506,6 +537,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
@@ -521,6 +553,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
@@ -537,6 +570,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData"
     ]
@@ -554,6 +588,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
@@ -570,6 +605,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
@@ -586,6 +622,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
@@ -602,6 +639,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
@@ -618,6 +656,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -634,6 +673,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -650,6 +690,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -666,6 +707,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -682,6 +724,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -698,6 +741,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -714,6 +758,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -730,6 +775,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -746,6 +792,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -762,6 +809,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:UpdateInstitutionData"
@@ -777,6 +825,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
@@ -792,6 +841,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
@@ -808,6 +858,7 @@
       "Selc:ManageProductUsers",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData"
     ]
@@ -820,7 +871,7 @@
       "Selc:AccessProductBackoffice",
       "Selc:ViewManagedInstitutions",
       "Selc:ViewDelegations",
-      "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
@@ -836,6 +887,7 @@
       "Selc:ViewDelegations",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"
     ],
@@ -850,6 +902,7 @@
       "Selc:ViewDelegations",
       "Selc:ListProductUsers",
       "Selc:ManageProductGroups",
+      "Selc:ListProductGroups",
       "Selc:ViewInstitutionData"
     ]
   },

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
@@ -2129,6 +2129,7 @@ class UserServiceTest {
                 "Selc:ManageProductUsers",
                 "Selc:ListProductUsers",
                 "Selc:ManageProductGroups",
+                "Selc:ListProductGroups",
                 "Selc:CreateDelegation",
                 "Selc:ViewInstitutionData"));
         userInstitutionWithActions.setInstitutionRootName("institutionRootName");
@@ -2152,7 +2153,7 @@ class UserServiceTest {
                 "Selc:AccessProductBackoffice",
                 "Selc:ViewManagedInstitutions",
                 "Selc:ViewDelegations",
-                "Selc:ManageProductGroups",
+                "Selc:ListProductGroups",
                 "Selc:CreateDelegation",
                 "Selc:ViewInstitutionData",
                 "Selc:ViewContract"));

--- a/apps/user-ms/src/test/resources/features/user.feature
+++ b/apps/user-ms/src/test/resources/features/user.feature
@@ -4272,6 +4272,7 @@ Feature: User
       | Selc:ManageProductUsers           |
       | Selc:ListProductUsers             |
       | Selc:ManageProductGroups          |
+      | Selc:ListProductGroups            |
       | Selc:CreateDelegation             |
       | Selc:ViewInstitutionData          |
       | Selc:ViewContract                 |
@@ -4306,6 +4307,7 @@ Feature: User
       | Selc:ManageProductUsers           |
       | Selc:ListProductUsers             |
       | Selc:ManageProductGroups          |
+      | Selc:ListProductGroups            |
       | Selc:CreateDelegation             |
       | Selc:ViewInstitutionData          |
 
@@ -4339,6 +4341,7 @@ Feature: User
       | Selc:ManageProductUsers           |
       | Selc:ListProductUsers             |
       | Selc:ManageProductGroups          |
+      | Selc:ListProductGroups            |
       | Selc:CreateDelegation             |
       | Selc:ViewInstitutionData          |
       | Selc:UpdateInstitutionData        |
@@ -4362,7 +4365,7 @@ Feature: User
       | products[0].role                  | MANAGER                                     |
       | products[0].env                   | ROOT                                        |
     And The response body contains the list "products" of size 1
-    And The response body contains the list "products[0].userProductActions" of size 13
+    And The response body contains the list "products[0].userProductActions" of size 14
     And The response body contains at path "products[0].userProductActions" the following list of values in any order:
       | Selc:UploadLogo                   |
       | Selc:ViewBilling                  |
@@ -4374,6 +4377,7 @@ Feature: User
       | Selc:ManageProductUsers           |
       | Selc:ListProductUsers             |
       | Selc:ManageProductGroups          |
+      | Selc:ListProductGroups            |
       | Selc:CreateDelegation             |
       | Selc:ViewInstitutionData          |
       | Selc:ViewContract                 |
@@ -4397,7 +4401,7 @@ Feature: User
       | products[0].role                  | DELEGATE                                    |
       | products[0].env                   | ROOT                                        |
     And The response body contains the list "products" of size 1
-    And The response body contains the list "products[0].userProductActions" of size 13
+    And The response body contains the list "products[0].userProductActions" of size 14
     And The response body contains at path "products[0].userProductActions" the following list of values in any order:
       | Selc:UploadLogo                   |
       | Selc:ViewBilling                  |
@@ -4409,6 +4413,7 @@ Feature: User
       | Selc:ManageProductUsers           |
       | Selc:ListProductUsers             |
       | Selc:ManageProductGroups          |
+      | Selc:ListProductGroups            |
       | Selc:CreateDelegation             |
       | Selc:ViewInstitutionData          |
       | Selc:ViewContract                 |
@@ -4432,7 +4437,7 @@ Feature: User
       | products[0].role                  | SUB_DELEGATE                                |
       | products[0].env                   | ROOT                                        |
     And The response body contains the list "products" of size 1
-    And The response body contains the list "products[0].userProductActions" of size 13
+    And The response body contains the list "products[0].userProductActions" of size 14
     And The response body contains at path "products[0].userProductActions" the following list of values in any order:
       | Selc:UploadLogo                   |
       | Selc:ViewBilling                  |
@@ -4444,6 +4449,7 @@ Feature: User
       | Selc:ManageProductUsers           |
       | Selc:ListProductUsers             |
       | Selc:ManageProductGroups          |
+      | Selc:ListProductGroups            |
       | Selc:CreateDelegation             |
       | Selc:ViewInstitutionData          |
       | Selc:ViewContract                 |
@@ -4493,7 +4499,7 @@ Feature: User
       | products[0].role                  | MANAGER                                     |
       | products[0].env                   | ROOT                                        |
     And The response body contains the list "products" of size 1
-    And The response body contains the list "products[0].userProductActions" of size 13
+    And The response body contains the list "products[0].userProductActions" of size 14
     And The response body contains at path "products[0].userProductActions" the following list of values in any order:
       | Selc:UploadLogo                   |
       | Selc:ViewBilling                  |
@@ -4505,6 +4511,7 @@ Feature: User
       | Selc:ManageProductUsers           |
       | Selc:ListProductUsers             |
       | Selc:ManageProductGroups          |
+      | Selc:ListProductGroups            |
       | Selc:CreateDelegation             |
       | Selc:ViewInstitutionData          |
       | Selc:ViewContract                 |
@@ -4528,7 +4535,7 @@ Feature: User
       | products[0].role                  | DELEGATE                                    |
       | products[0].env                   | ROOT                                        |
     And The response body contains the list "products" of size 1
-    And The response body contains the list "products[0].userProductActions" of size 13
+    And The response body contains the list "products[0].userProductActions" of size 14
     And The response body contains at path "products[0].userProductActions" the following list of values in any order:
       | Selc:UploadLogo                   |
       | Selc:ViewBilling                  |
@@ -4540,6 +4547,7 @@ Feature: User
       | Selc:ManageProductUsers           |
       | Selc:ListProductUsers             |
       | Selc:ManageProductGroups          |
+      | Selc:ListProductGroups            |
       | Selc:CreateDelegation             |
       | Selc:ViewInstitutionData          |
       | Selc:ViewContract                 |
@@ -4563,7 +4571,7 @@ Feature: User
       | products[0].role                  | SUB_DELEGATE                                |
       | products[0].env                   | ROOT                                        |
     And The response body contains the list "products" of size 1
-    And The response body contains the list "products[0].userProductActions" of size 13
+    And The response body contains the list "products[0].userProductActions" of size 14
     And The response body contains at path "products[0].userProductActions" the following list of values in any order:
       | Selc:UploadLogo                   |
       | Selc:ViewBilling                  |
@@ -4575,6 +4583,7 @@ Feature: User
       | Selc:ManageProductUsers           |
       | Selc:ListProductUsers             |
       | Selc:ManageProductGroups          |
+      | Selc:ListProductGroups            |
       | Selc:CreateDelegation             |
       | Selc:ViewInstitutionData          |
       | Selc:ViewContract                 |
@@ -4661,6 +4670,7 @@ Feature: User
       | Selc:ManageProductUsers           |
       | Selc:ListProductUsers             |
       | Selc:ManageProductGroups          |
+      | Selc:ListProductGroups            |
       | Selc:CreateDelegation             |
       | Selc:ViewInstitutionData          |
       | Selc:ViewContract                 |
@@ -4696,6 +4706,7 @@ Feature: User
       | Selc:ManageProductUsers           |
       | Selc:ListProductUsers             |
       | Selc:ManageProductGroups          |
+      | Selc:ListProductGroups            |
       | Selc:CreateDelegation             |
       | Selc:ViewInstitutionData          |
       | Selc:ViewContract                 |
@@ -4730,6 +4741,7 @@ Feature: User
       | Selc:ViewDelegations              |
       | Selc:ListProductUsers             |
       | Selc:ManageProductGroups          |
+      | Selc:ListProductGroups            |
       | Selc:ViewInstitutionData          |
       | Selc:ViewContract                 |
 
@@ -4759,7 +4771,7 @@ Feature: User
       | Selc:AccessProductBackoffice      |
       | Selc:ViewManagedInstitutions      |
       | Selc:ViewDelegations              |
-      | Selc:ManageProductGroups          |
+      | Selc:ListProductGroups            |
       | Selc:CreateDelegation             |
       | Selc:ViewInstitutionData          |
       | Selc:ViewContract                 |
@@ -4794,6 +4806,7 @@ Feature: User
       | Selc:ViewDelegations              |
       | Selc:ListProductUsers             |
       | Selc:ManageProductGroups          |
+      | Selc:ListProductGroups            |
       | Selc:ViewInstitutionData          |
 
   @RemoveUserInstitutionAndUserInfoAfterScenario
@@ -4828,6 +4841,7 @@ Feature: User
       | Selc:ViewDelegations              |
       | Selc:ListProductUsers             |
       | Selc:ManageProductGroups          |
+      | Selc:ListProductGroups            |
       | Selc:ViewInstitutionData          |
 
   @RemoveUserInstitutionAndUserInfoAfterScenario


### PR DESCRIPTION
#### List of Changes

- Added new action ListProductGroups
- Removed action ManageProductGroups from ADMIN_EA role for prod-io

#### Motivation and Context

Added a new action which allows users to view only the groups they are a member of without modifying them: ADMIN_EA users for prod-io will not be able to manage groups.

#### How Has This Been Tested?

- Local tests
- Unit tests
- Integration tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.