### PR TITLE
[SELC-7480] Temporarily restored ManageProductGroups permission for ADMIN_EA prod-io users

### DIFF
--- a/apps/user-ms/src/main/resources/role_action_mapping.json
+++ b/apps/user-ms/src/main/resources/role_action_mapping.json
@@ -871,6 +871,7 @@
       "Selc:AccessProductBackoffice",
       "Selc:ViewManagedInstitutions",
       "Selc:ViewDelegations",
+      "Selc:ManageProductGroups",
       "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
@@ -2153,6 +2153,7 @@ class UserServiceTest {
                 "Selc:AccessProductBackoffice",
                 "Selc:ViewManagedInstitutions",
                 "Selc:ViewDelegations",
+                "Selc:ManageProductGroups",
                 "Selc:ListProductGroups",
                 "Selc:CreateDelegation",
                 "Selc:ViewInstitutionData",

--- a/apps/user-ms/src/test/resources/features/user.feature
+++ b/apps/user-ms/src/test/resources/features/user.feature
@@ -4771,6 +4771,7 @@ Feature: User
       | Selc:AccessProductBackoffice      |
       | Selc:ViewManagedInstitutions      |
       | Selc:ViewDelegations              |
+      | Selc:ManageProductGroups          |
       | Selc:ListProductGroups            |
       | Selc:CreateDelegation             |
       | Selc:ViewInstitutionData          |


### PR DESCRIPTION
#### List of Changes

- Temporarily restored ManageProductGroups permission for ADMIN_EA prod-io users

#### Motivation and Context

The permission will be removed at a later date when aggregators are able to manage groups of their aggregates

#### How Has This Been Tested?

- Local tests
- Unit tests
- Integration tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.