### PR TITLE
[SELC-7461] feat: add parentInstitutionId in UserGroups model

### DIFF
--- a/apps/user-group-cdc/src/main/java/it/pagopa/selfcare/user/event/entity/UserGroupEntity.java
+++ b/apps/user-group-cdc/src/main/java/it/pagopa/selfcare/user/event/entity/UserGroupEntity.java
@@ -19,6 +19,7 @@ public class UserGroupEntity extends ReactivePanacheMongoEntity {
     private ObjectId id;
     private String institutionId;
     private String productId;
+    private String parentInstitutionId;
     private String name;
     private String description;
     private String status;

--- a/apps/user-group-ms/src/main/java/it/pagopa/selfcare/user_group/api/UserGroupOperations.java
+++ b/apps/user-group-ms/src/main/java/it/pagopa/selfcare/user_group/api/UserGroupOperations.java
@@ -16,6 +16,10 @@ public interface UserGroupOperations {
 
     void setInstitutionId(String institutionId);
 
+    String getParentInstitutionId();
+
+    void setParentInstitutionId(String parentInstitutionId);
+
     String getProductId();
 
     void setProductId(String productId);

--- a/apps/user-group-ms/src/main/java/it/pagopa/selfcare/user_group/model/GroupDto.java
+++ b/apps/user-group-ms/src/main/java/it/pagopa/selfcare/user_group/model/GroupDto.java
@@ -10,6 +10,7 @@ import java.util.Set;
 public class GroupDto implements UserGroupOperations {
     private String id;
     private String institutionId;
+    private String parentInstitutionId;
     private String productId;
     private String name;
     private String description;

--- a/apps/user-group-ms/src/main/java/it/pagopa/selfcare/user_group/model/UserGroupEntity.java
+++ b/apps/user-group-ms/src/main/java/it/pagopa/selfcare/user_group/model/UserGroupEntity.java
@@ -20,6 +20,7 @@ public class UserGroupEntity implements UserGroupOperations {
         this();
         id = userGroup.getId();
         institutionId = userGroup.getInstitutionId();
+        parentInstitutionId = userGroup.getParentInstitutionId();
         productId = userGroup.getProductId();
         name = userGroup.getName();
         description = userGroup.getDescription();
@@ -35,6 +36,8 @@ public class UserGroupEntity implements UserGroupOperations {
     private String id;
     @FieldNameConstants.Include
     private String institutionId;
+    @FieldNameConstants.Include
+    private String parentInstitutionId;
     @FieldNameConstants.Include
     private String productId;
     private String name;

--- a/apps/user-group-ms/src/test/java/it/pagopa/selfcare/user_group/model/DummyGroup.java
+++ b/apps/user-group-ms/src/test/java/it/pagopa/selfcare/user_group/model/DummyGroup.java
@@ -12,6 +12,7 @@ public class DummyGroup implements UserGroupOperations {
 
     private String id;
     private String institutionId;
+    private String parentInstitutionId;
     private String productId;
     private String name;
     private String description;

--- a/apps/user-group-ms/src/test/resources/application-test.properties
+++ b/apps/user-group-ms/src/test/resources/application-test.properties
@@ -1,3 +1,7 @@
 user-group.allowed.sorting.parameters=name
 spring.data.mongodb.uri=mongodb://localhost:27017
 spring.data.mongodb.database=selcUserGroup
+
+spring.jackson.time-zone=GMT
+spring.mvc.locale=en_US
+spring.mvc.locale-resolver=fixed

--- a/apps/user-group-ms/src/test/resources/features/createGroup.feature
+++ b/apps/user-group-ms/src/test/resources/features/createGroup.feature
@@ -31,7 +31,7 @@ Feature: Create User Group
     And [CREATE] the response should contain an error message "A group with the same name already exists in ACTIVE or SUSPENDED state"
 
   # Scenario negativo: Dettagli del gruppo mancanti (name non fornito)
-  Scenario: Attempt to create a user group with missing required fields
+  Scenario: Attempt to create a user group with missing required fields (name)
     Given [CREATE] user login with username "j.doe" and password "test"
     And the following user group details:
       | description | productId  | institutionId | status | members                                                                   |
@@ -41,7 +41,7 @@ Feature: Create User Group
     And [CREATE] the response should contain an error message "createUserGroupDto.name,must not be blank"
 
   # Scenario negativo: Dettagli del gruppo mancanti (institutionId non fornito)
-  Scenario: Attempt to create a user group with missing required fields
+  Scenario: Attempt to create a user group with missing required fields (institutionId)
     Given [CREATE] user login with username "j.doe" and password "test"
     And the following user group details:
       | name       | description | productId  | status | members                                                                   |
@@ -51,7 +51,7 @@ Feature: Create User Group
     And [CREATE] the response should contain an error message "createUserGroupDto.institutionId,must not be blank"
 
   # Scenario negativo: Dettagli del gruppo mancanti (productId non fornito)
-  Scenario: Attempt to create a user group with missing required fields
+  Scenario: Attempt to create a user group with missing required fields (productId)
     Given [CREATE] user login with username "j.doe" and password "test"
     And the following user group details:
       | name       | description | institutionId | status | members                                                                   |
@@ -61,7 +61,7 @@ Feature: Create User Group
     And [CREATE] the response should contain an error message "createUserGroupDto.productId,must not be blank"
 
   # Scenario negativo: Dettagli del gruppo mancanti (description non fornito)
-  Scenario: Attempt to create a user group with missing required fields
+  Scenario: Attempt to create a user group with missing required fields (description)
     Given [CREATE] user login with username "j.doe" and password "test"
     And the following user group details:
       | name       | productId  | institutionId | status | members                                                                   |
@@ -71,7 +71,7 @@ Feature: Create User Group
     And [CREATE] the response should contain an error message "createUserGroupDto.description,must not be blank"
 
   # Scenario negativo: Dettagli del gruppo mancanti (status non fornito)
-  Scenario: Attempt to create a user group with missing required fields
+  Scenario: Attempt to create a user group with missing required fields (status)
     Given [CREATE] user login with username "j.doe" and password "test"
     And the following user group details:
       | name       | description | productId  | institutionId | members                                                                   |
@@ -81,7 +81,7 @@ Feature: Create User Group
     And [CREATE] the response should contain an error message "createUserGroupDto.status,must not be null"
 
   # Scenario negativo: Dettagli del gruppo mancanti (members vuoto)
-  Scenario: Attempt to create a user group with missing required fields
+  Scenario: Attempt to create a user group with missing required fields (members)
     Given [CREATE] user login with username "j.doe" and password "test"
     And the following user group details:
       | name       | description | productId  | institutionId | status | members |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- add parentInstitutionId in UserGroups model
- set english as default cucumber tests' language

<!--- Describe your changes in detail -->

#### Motivation and Context
The parentInstitutionId field has been introduced to support the case of aggregator institutions. It allows us to identify when a user group is associated with an aggregator entity and to specify which aggregator it belongs to. This ensures clearer relationships between institutions and their respective groups.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested locally

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.