### PR TITLE
[SELC-7870] feat: remove ManageProductUsers and ListProductUsers actions from ADMIN_EA role for prod-io

### DIFF
--- a/apps/user-ms/src/main/resources/role_action_mapping.json
+++ b/apps/user-ms/src/main/resources/role_action_mapping.json
@@ -968,8 +968,6 @@
       "Selc:ViewManagedInstitutions",
       "Selc:ViewDelegations",
       "Selc:ListProductUsers",
-      "Selc:ManageProductGroups",
-      "Selc:ListProductGroups",
       "Selc:CreateDelegation",
       "Selc:ViewInstitutionData",
       "Selc:ViewContract"

--- a/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
+++ b/apps/user-ms/src/test/java/it/pagopa/selfcare/user/service/UserServiceTest.java
@@ -2171,8 +2171,6 @@ class UserServiceTest {
                 "Selc:ViewManagedInstitutions",
                 "Selc:ViewDelegations",
                 "Selc:ListProductUsers",
-                "Selc:ManageProductGroups",
-                "Selc:ListProductGroups",
                 "Selc:CreateDelegation",
                 "Selc:ViewInstitutionData",
                 "Selc:ViewContract"));

--- a/apps/user-ms/src/test/resources/features/user.feature
+++ b/apps/user-ms/src/test/resources/features/user.feature
@@ -4967,8 +4967,6 @@ Feature: User
       | Selc:ViewManagedInstitutions      |
       | Selc:ViewDelegations              |
       | Selc:ListProductUsers             |
-      | Selc:ManageProductGroups          |
-      | Selc:ListProductGroups            |
       | Selc:CreateDelegation             |
       | Selc:ViewInstitutionData          |
       | Selc:ViewContract                 |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- removed ManageProductUsers and ListProductUsers from ADMIN_EA role for prod-io
- aligned unit tests
- aligned cucumber tests

<!--- Describe your changes in detail -->

#### Motivation and Context
Users with ADMIN_EA role for prod-io do not have to list and manage users

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
locally and by unit tests and cucumber tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.